### PR TITLE
[FE]Text Button 구현

### DIFF
--- a/front-end/src/components/button/text/ClassCloseButton.tsx
+++ b/front-end/src/components/button/text/ClassCloseButton.tsx
@@ -1,0 +1,15 @@
+import S from './TextButton.module.css';
+
+type ClassCloseButtonProps = {
+  onClick: () => void;
+};
+
+const ClassCloseButton = ({ onClick }: ClassCloseButtonProps) => {
+  return (
+    <button className={S.classCloseButton} onClick={onClick}>
+      수업 끝내기
+    </button>
+  );
+};
+
+export default ClassCloseButton;

--- a/front-end/src/components/button/text/TextButton.module.css
+++ b/front-end/src/components/button/text/TextButton.module.css
@@ -4,6 +4,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  word-break: keep-all;
 }
 
 .textButton:not(:disabled):hover {

--- a/front-end/src/components/button/text/TextButton.module.css
+++ b/front-end/src/components/button/text/TextButton.module.css
@@ -1,0 +1,84 @@
+.textButton {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.textButton:not(:disabled):hover {
+  opacity: 0.8;
+}
+
+.webButton1 {
+  border-radius: 20px;
+  font: var(--web-button1-bold);
+}
+
+.webButton2 {
+  border-radius: 12px;
+  font: var(--web-button2-bold);
+}
+
+.webButton3 {
+  border-radius: 12px;
+  font: var(--web-button3-bold);
+}
+
+.webButton4 {
+  border-radius: 12px;
+  font: var(--web-button4-bold);
+}
+
+.mobileButton1 {
+  border-radius: 8px;
+  font: var(--mobile-button1-bold);
+}
+
+.mobileButton2 {
+  border-radius: 4px;
+  font: var(--mobile-button2-bold);
+}
+
+.blueButton {
+  background-color: var(--blue-400);
+  color: white;
+}
+
+.blueButton:disabled {
+  background-color: var(--gray-300);
+  color: var(--gray-500);
+}
+
+.whiteButton {
+  background-color: white;
+  color: var(--blue-400);
+  border: 1px solid var(--blue-400);
+}
+
+.blackButton {
+  background-color: var(--gray-900);
+  color: white;
+}
+
+.redButton {
+  background-color: var(--error-red-500);
+  color: white;
+}
+
+.inheritButton {
+  background-color: inherit;
+  color: white;
+  border: 3px solid white;
+}
+
+.greenButton {
+  background-color: var(--sub-green-500);
+  color: white;
+}
+
+.classCloseButton {
+  composes: blueButton;
+  border-radius: 0px;
+  font: var(--web-button2-bold);
+}

--- a/front-end/src/components/button/text/TextButton.tsx
+++ b/front-end/src/components/button/text/TextButton.tsx
@@ -1,0 +1,75 @@
+import S from './TextButton.module.css';
+
+type TextButtonProps = {
+  color: 'blue' | 'red' | 'green' | 'black' | 'white' | 'inherit';
+  size: 'web1' | 'web2' | 'web3' | 'web4' | 'mobile1' | 'mobile2';
+  width?: string;
+  height?: string;
+  text: string;
+  isActive?: boolean;
+  onClick: () => void;
+};
+
+const TextButton = ({
+  color,
+  size,
+  width,
+  height,
+  text,
+  onClick,
+  isActive = true,
+}: TextButtonProps): JSX.Element => {
+  let colorClass, sizeClass;
+  switch (color) {
+    case 'blue':
+      colorClass = S.blueButton;
+      break;
+    case 'red':
+      colorClass = S.redButton;
+      break;
+    case 'green':
+      colorClass = S.greenButton;
+      break;
+    case 'black':
+      colorClass = S.blackButton;
+      break;
+    case 'white':
+      colorClass = S.whiteButton;
+      break;
+    case 'inherit':
+      colorClass = S.inheritButton;
+  }
+
+  switch (size) {
+    case 'web1':
+      sizeClass = S.webButton1;
+      break;
+    case 'web2':
+      sizeClass = S.webButton2;
+      break;
+    case 'web3':
+      sizeClass = S.webButton3;
+      break;
+    case 'web4':
+      sizeClass = S.webButton4;
+      break;
+    case 'mobile1':
+      sizeClass = S.mobileButton1;
+      break;
+    case 'mobile2':
+      sizeClass = S.mobileButton2;
+  }
+
+  return (
+    <button
+      style={{ width: width, height: height }}
+      className={`${S.textButton} ${colorClass} ${sizeClass}`}
+      disabled={!isActive}
+      onClick={onClick}
+    >
+      {text}
+    </button>
+  );
+};
+
+export default TextButton;

--- a/front-end/src/components/button/text/TextButton.tsx
+++ b/front-end/src/components/button/text/TextButton.tsx
@@ -10,6 +10,44 @@ type TextButtonProps = {
   onClick: () => void;
 };
 
+function getColorClass(color: string): keyof typeof S {
+  switch (color) {
+    case 'blue':
+      return 'blueButton';
+    case 'red':
+      return 'redButton';
+    case 'green':
+      return 'greenButton';
+    case 'black':
+      return 'blackButton';
+    case 'white':
+      return 'whiteButton';
+    case 'inherit':
+      return 'inheritButton';
+    default:
+      return 'blueButton';
+  }
+}
+
+function getSizeClass(size: string): keyof typeof S {
+  switch (size) {
+    case 'web1':
+      return 'webButton1';
+    case 'web2':
+      return 'webButton2';
+    case 'web3':
+      return 'webButton3';
+    case 'web4':
+      return 'webButton4';
+    case 'mobile1':
+      return 'mobileButton1';
+    case 'mobile2':
+      return 'mobileButton2';
+    default:
+      return 'webButton1';
+  }
+}
+
 const TextButton = ({
   color,
   size,
@@ -19,46 +57,8 @@ const TextButton = ({
   onClick,
   isActive = true,
 }: TextButtonProps): JSX.Element => {
-  let colorClass, sizeClass;
-  switch (color) {
-    case 'blue':
-      colorClass = S.blueButton;
-      break;
-    case 'red':
-      colorClass = S.redButton;
-      break;
-    case 'green':
-      colorClass = S.greenButton;
-      break;
-    case 'black':
-      colorClass = S.blackButton;
-      break;
-    case 'white':
-      colorClass = S.whiteButton;
-      break;
-    case 'inherit':
-      colorClass = S.inheritButton;
-  }
-
-  switch (size) {
-    case 'web1':
-      sizeClass = S.webButton1;
-      break;
-    case 'web2':
-      sizeClass = S.webButton2;
-      break;
-    case 'web3':
-      sizeClass = S.webButton3;
-      break;
-    case 'web4':
-      sizeClass = S.webButton4;
-      break;
-    case 'mobile1':
-      sizeClass = S.mobileButton1;
-      break;
-    case 'mobile2':
-      sizeClass = S.mobileButton2;
-  }
+  const colorClass = getColorClass(color);
+  const sizeClass = getSizeClass(size);
 
   return (
     <button


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #5 

## 📝 작업 내용

- Text Button 추상화 방식 변경
- "수업 끝내기" 버튼 분리
- Text Button Component 구현

## 💬 리뷰 요구사항(선택)

- size의 web1 ~ 4, mobile 1 ~ 2는 디자인 시스템의 숫자와 같습니다
