### PR TITLE
[BE] Google OAuth를 통한 회원가입&로그인 기능 구현

### DIFF
--- a/back-end/reacton/build.gradle
+++ b/back-end/reacton/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/back-end/reacton/build.gradle
+++ b/back-end/reacton/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/Professor.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/Professor.java
@@ -1,9 +1,13 @@
 package com.softeer.reacton.domain.professor;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "professor")
 @Entity
 public class Professor {
@@ -23,5 +27,17 @@ public class Professor {
 
     @Column(length = 512)
     private String profileImgUrl;
+
+    @Builder
+    public Professor(String email, String name, String oauthId, String profileImgUrl) {
+        this.email = email;
+        this.name = name;
+        this.oauthId = oauthId;
+        this.profileImgUrl = profileImgUrl;
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
+    }
 
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorRepository.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorRepository.java
@@ -2,5 +2,8 @@ package com.softeer.reacton.domain.professor;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ProfessorRepository extends JpaRepository<Professor, Long> {
+    Optional<Professor> findByOauthId(String oauthId);
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/config/WebClientConfig.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/config/WebClientConfig.java
@@ -1,0 +1,15 @@
+package com.softeer.reacton.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder()
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/jwt/JwtAuthenticationFilter.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package com.softeer.reacton.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenUtil jwtTokenUtil;
+
+    private static final String TOKEN_COOKIE_NAME = "access_token";
+    private static final String AUTH_ERROR_MESSAGE = "Unauthorized: Invalid or Expired JWT Token";
+
+    private static final List<String> WHITE_LIST_URLS = List.of(
+            "/auth/google/url",
+            "/auth/google/callback"
+    );
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        String requestUri = request.getRequestURI();
+        if (isWhiteListed(requestUri)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String token = getJwtFromCookie(request);
+        if (token != null && jwtTokenUtil.validateToken(token)) {
+            String oauthId = jwtTokenUtil.getUserOauthId(token);
+            request.setAttribute("oauthId", oauthId);
+        } else {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, AUTH_ERROR_MESSAGE);
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private boolean isWhiteListed(String requestUri) {
+        return WHITE_LIST_URLS.stream().anyMatch(requestUri::startsWith);
+    }
+
+    private String getJwtFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> TOKEN_COOKIE_NAME.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/jwt/JwtTokenUtil.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/jwt/JwtTokenUtil.java
@@ -41,4 +41,22 @@ public class JwtTokenUtil {
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public String getUserOauthId(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/jwt/JwtTokenUtil.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/jwt/JwtTokenUtil.java
@@ -1,0 +1,44 @@
+package com.softeer.reacton.global.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtTokenUtil {
+
+    private final Key secretKey;
+    private final long accessTokenValidity;
+
+    public JwtTokenUtil(
+            @Value("${jwt.secret-key}") String secretKey,
+            @Value("${jwt.access-token.expire-length}") long accessTokenValidity) {
+
+        String encodedKey = Base64.getEncoder().encodeToString(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.secretKey = Keys.hmacShaKeyFor(encodedKey.getBytes());
+        this.accessTokenValidity = accessTokenValidity;
+    }
+
+    public String createAccessToken(String oauthId) {
+        return createToken(oauthId, accessTokenValidity);
+    }
+
+    private String createToken(String payload, long expireLength) {
+        Claims claims = Jwts.claims().setSubject(payload);
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + expireLength);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiration)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthConfig.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthConfig.java
@@ -1,0 +1,31 @@
+package com.softeer.reacton.global.oauth;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OAuthConfig {
+
+    @Value("${oauth.google.login-url}")
+    private String googleLoginUrl;
+    @Value("${oauth.google.client-id}")
+    private String googleClientId;
+    @Value("${oauth.google.client-secret}")
+    private String googleClientSecret;
+    @Value("${oauth.google.redirect-uri}")
+    private String googleRedirectUri;
+    @Value("${oauth.google.token-uri}")
+    private String googleTokenUri;
+    @Value("${oauth.google.user-info-uri}")
+    private String googleUserInfoUri;
+    @Value("${oauth.google.scope}")
+    private String googleScope;
+
+
+    public OAuthProvider getProvider(String provider) {
+        if (provider.equalsIgnoreCase("google")) {
+            return new OAuthProvider(googleLoginUrl, googleClientId, googleClientSecret, googleRedirectUri, googleTokenUri, googleUserInfoUri, googleScope);
+        }
+        throw new IllegalArgumentException("지원되지 않는 OAuth 제공자: " + provider);
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthController.java
@@ -2,6 +2,7 @@ package com.softeer.reacton.global.oauth;
 
 import com.softeer.reacton.global.oauth.dto.LoginResponse;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -11,13 +12,10 @@ import java.io.IOException;
 
 @RestController
 @RequestMapping("/auth")
+@RequiredArgsConstructor
 public class OAuthController {
 
     private final OAuthService oauthService;
-
-    public OAuthController(OAuthService oauthService) {
-        this.oauthService = oauthService;
-    }
 
     @GetMapping("/{provider}/url")
     public void getOauthLoginUrl(HttpServletResponse response, @PathVariable String provider) throws IOException {

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthController.java
@@ -1,14 +1,13 @@
 package com.softeer.reacton.global.oauth;
 
 import com.softeer.reacton.global.oauth.dto.LoginResponse;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
 
 @RestController
 @RequestMapping("/auth")
@@ -18,24 +17,28 @@ public class OAuthController {
     private final OAuthService oauthService;
 
     @GetMapping("/{provider}/url")
-    public void getOauthLoginUrl(HttpServletResponse response, @PathVariable String provider) throws IOException {
-        response.sendRedirect(oauthService.getOauthLoginUrl(provider));
+    public ResponseEntity<Void> getOauthLoginUrl(@PathVariable String provider) {
+        String oauthLoginUrl = oauthService.getOauthLoginUrl(provider);
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .header(HttpHeaders.LOCATION, oauthLoginUrl)
+                .build();
     }
 
     @GetMapping("/{provider}/callback")
-    public ResponseEntity<LoginResponse> oauthCallback(HttpServletResponse response, @PathVariable String provider, @RequestParam String code) {
+    public ResponseEntity<LoginResponse> oauthCallback(@PathVariable String provider, @RequestParam String code) {
         LoginResponse loginResponse = oauthService.processOauthLogin(provider, code);
 
         ResponseCookie jwtCookie = ResponseCookie.from("access_token", loginResponse.getAccessToken())
                 .httpOnly(true)
-                .secure(false) // HTTP에서도 쿠키 전송 가능하도록 설정 (배포 환경에서는 true로 변경)
+                .secure(false) // TODO : HTTP에서도 쿠키 전송 가능하도록 설정 (배포 환경에서는 true로 변경)
                 .path("/")
                 .maxAge(60 * 60 * 24)
                 .sameSite("Strict")
                 .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, jwtCookie.toString());
 
         // TODO : 프론트 리다이렉트 코드 추가 예정
-        return ResponseEntity.ok(loginResponse);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, jwtCookie.toString())
+                .body(loginResponse);
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthController.java
@@ -23,4 +23,21 @@ public class OAuthController {
     public void getOauthLoginUrl(HttpServletResponse response, @PathVariable String provider) throws IOException {
         response.sendRedirect(oauthService.getOauthLoginUrl(provider));
     }
+
+    @GetMapping("/{provider}/callback")
+    public ResponseEntity<LoginResponse> oauthCallback(HttpServletResponse response, @PathVariable String provider, @RequestParam String code) {
+        LoginResponse loginResponse = oauthService.processOauthLogin(provider, code);
+
+        ResponseCookie jwtCookie = ResponseCookie.from("access_token", loginResponse.getAccessToken())
+                .httpOnly(true)
+                .secure(false) // HTTP에서도 쿠키 전송 가능하도록 설정 (배포 환경에서는 true로 변경)
+                .path("/")
+                .maxAge(60 * 60 * 24)
+                .sameSite("Strict")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, jwtCookie.toString());
+
+        // TODO : 프론트 리다이렉트 코드 추가 예정
+        return ResponseEntity.ok(loginResponse);
+    }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthController.java
@@ -1,0 +1,26 @@
+package com.softeer.reacton.global.oauth;
+
+import com.softeer.reacton.global.oauth.dto.LoginResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/auth")
+public class OAuthController {
+
+    private final OAuthService oauthService;
+
+    public OAuthController(OAuthService oauthService) {
+        this.oauthService = oauthService;
+    }
+
+    @GetMapping("/{provider}/url")
+    public void getOauthLoginUrl(HttpServletResponse response, @PathVariable String provider) throws IOException {
+        response.sendRedirect(oauthService.getOauthLoginUrl(provider));
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthProvider.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthProvider.java
@@ -1,0 +1,18 @@
+package com.softeer.reacton.global.oauth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OAuthProvider {
+    private final String loginUrl;
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
+    private final String tokenUri;
+    private final String userInfoUri;
+    private final String scope;
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthService.java
@@ -1,0 +1,40 @@
+package com.softeer.reacton.global.oauth;
+
+import com.softeer.reacton.domain.professor.Professor;
+import com.softeer.reacton.domain.professor.ProfessorRepository;
+import com.softeer.reacton.global.jwt.JwtTokenUtil;
+import com.softeer.reacton.global.oauth.dto.GoogleUserProfile;
+import com.softeer.reacton.global.oauth.dto.LoginResponse;
+import com.softeer.reacton.global.oauth.dto.OAuthTokenResponse;
+import com.softeer.reacton.global.oauth.dto.UserProfile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Service
+public class OAuthService {
+
+    private final OAuthConfig oauthConfig;
+
+    public OAuthService(OAuthConfig oauthConfig) {
+        this.oauthConfig = oauthConfig;
+    }
+
+    public String getOauthLoginUrl(String providerName) {
+        OAuthProvider provider = oauthConfig.getProvider(providerName);
+        StringBuilder urlBuilder = new StringBuilder(provider.getLoginUrl());
+
+        urlBuilder.append("?scope=").append(URLEncoder.encode(provider.getScope(), StandardCharsets.UTF_8))
+                .append("&client_id=").append(provider.getClientId())
+                .append("&redirect_uri=").append(URLEncoder.encode(provider.getRedirectUri(), StandardCharsets.UTF_8))
+                .append("&response_type=code");
+
+        return urlBuilder.toString();
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthService.java
@@ -21,10 +21,18 @@ import java.nio.charset.StandardCharsets;
 public class OAuthService {
 
     private final OAuthConfig oauthConfig;
+    private final JwtTokenUtil jwtTokenUtil;
+    private final ProfessorRepository professorRepository;
+    private final WebClient webClient;
 
-    public OAuthService(OAuthConfig oauthConfig) {
+    public OAuthService(OAuthConfig oauthConfig, JwtTokenUtil jwtTokenUtil,
+                        ProfessorRepository professorRepository, WebClient webClient) {
         this.oauthConfig = oauthConfig;
+        this.jwtTokenUtil = jwtTokenUtil;
+        this.professorRepository = professorRepository;
+        this.webClient = webClient;
     }
+
 
     public String getOauthLoginUrl(String providerName) {
         OAuthProvider provider = oauthConfig.getProvider(providerName);
@@ -36,5 +44,71 @@ public class OAuthService {
                 .append("&response_type=code");
 
         return urlBuilder.toString();
+    }
+
+
+    public LoginResponse processOauthLogin(String providerName, String code) {
+        OAuthProvider provider = oauthConfig.getProvider(providerName);
+
+        OAuthTokenResponse tokenResponse = getAccessTokenByOauth(code, provider);
+        UserProfile userProfile = getUserProfile(providerName, provider, tokenResponse);
+
+        Professor professor = saveOrUpdate(userProfile);
+
+        String accessToken = jwtTokenUtil.createAccessToken(userProfile.getEmail());
+
+        return LoginResponse.builder()
+                .id(professor.getId())
+                .name(professor.getName())
+                .email(professor.getEmail())
+                .imageUrl(professor.getProfileImgUrl())
+                .tokenType("Bearer")
+                .accessToken(accessToken)
+                .build();
+    }
+
+    private OAuthTokenResponse getAccessTokenByOauth(String code, OAuthProvider provider) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        System.out.println(code);
+        formData.add("code", code);
+        formData.add("client_id", provider.getClientId());
+        formData.add("client_secret", provider.getClientSecret());
+        formData.add("redirect_uri", provider.getRedirectUri());
+        formData.add("grant_type", "authorization_code");
+
+        return webClient.post()
+                .uri(provider.getTokenUri())
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .bodyValue(formData)
+                .retrieve()
+                .bodyToMono(OAuthTokenResponse.class)
+                .block();
+    }
+
+    private UserProfile getUserProfile(String providerName, OAuthProvider provider, OAuthTokenResponse tokenResponse) {
+        if ("google".equals(providerName)) {
+            return webClient.get()
+                    .uri(provider.getUserInfoUri())
+                    .headers(header -> header.setBearerAuth(tokenResponse.getAccessToken()))
+                    .retrieve()
+                    .bodyToMono(GoogleUserProfile.class)
+                    .block();
+        }
+
+        throw new IllegalArgumentException("지원하지 않는 OAuth 제공자: " + provider);
+    }
+
+    private Professor saveOrUpdate(UserProfile userProfile) {
+        Professor professor = professorRepository.findByOauthId(userProfile.getOauthId())
+                .map(entity -> {
+                    // 이메일이 변경된 경우에만 업데이트
+                    if (!entity.getEmail().equals(userProfile.getEmail())) {
+                        entity.updateEmail(userProfile.getEmail());
+                    }
+                    return entity;
+                })
+                .orElse(userProfile.toProfessor());
+
+        return professorRepository.save(professor);
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/dto/GoogleUserProfile.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/dto/GoogleUserProfile.java
@@ -1,0 +1,34 @@
+package com.softeer.reacton.global.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.softeer.reacton.domain.professor.Professor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GoogleUserProfile implements UserProfile {
+    @JsonProperty("sub")
+    private final String oauthId;
+    private final String email;
+    private final String name;
+    @JsonProperty("picture")
+    private final String imageUrl;
+
+    @Builder
+    public GoogleUserProfile(String oauthId, String email, String name, String imageUrl) {
+        this.oauthId = oauthId;
+        this.email = email;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+
+    @Override
+    public Professor toProfessor() {
+        return Professor.builder()
+                .oauthId(oauthId)
+                .email(email)
+                .name(name)
+                .profileImgUrl(imageUrl)
+                .build();
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/dto/LoginResponse.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/dto/LoginResponse.java
@@ -1,0 +1,15 @@
+package com.softeer.reacton.global.oauth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponse {
+    private Long id;
+    private String name;
+    private String email;
+    private String imageUrl;
+    private String tokenType;
+    private String accessToken;
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/dto/OAuthTokenResponse.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/dto/OAuthTokenResponse.java
@@ -1,0 +1,21 @@
+package com.softeer.reacton.global.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OAuthTokenResponse {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    private String scope;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/dto/UserProfile.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/dto/UserProfile.java
@@ -1,0 +1,15 @@
+package com.softeer.reacton.global.oauth.dto;
+
+import com.softeer.reacton.domain.professor.Professor;
+
+public interface UserProfile {
+    String getOauthId();
+
+    String getEmail();
+
+    String getName();
+
+    String getImageUrl();
+
+    Professor toProfessor();
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#11 [BE] Google OAuth를 통한 회원가입&로그인 기능 구현 

## 📝 작업 내용
OAuth 로그인 및 JWT 인증을 구현하여 사용자의 인증 및 권한 관리를 할 수 있도록 했습니다.

### 로그인 URL 반환 API
- OAuth 설정 : `OAuthProvider`, `OAuthConfig`추가 (provider별 설정값 관리)
- OAuth 로그인 URL API 추가 : /auth/{provider}/url

### 로그인 로직 수행 API
- OAuth 사용자 정보 처리 : `UserProfile`, `GoogleUserProfile` 추가
- WebClient 설정 : `WebClient Bean` 등록
- JWT 토큰 발급 기능 추가 : `JwtTokenUtil` 구현
- OAuth 로그인 과정 구현 : /auth/{provider}/callback API 추가
- JWT 인증 필터 추가 : `JwtAuthenticationFilter` 구현

---

### 🚀 [테스트 방법]
1. /auth/google/url 요청 → OAuth 로그인 URL 반환
2. 브라우저에서 해당 URL을 통해 로그인 진행
3. 로그인 성공 시 JWT 토큰이 HttpOnly 쿠키에 저장됨
4. 보호된 API 요청 시 JWT 인증 필터에서 검증 수행

### 🔍 [추가 작업 예정]
- OAuth 로그인 성공 후 프론트엔드로의 리다이렉트 처리
- 배포시에는 쿠키 secure 설정 true로 변경