### PR TITLE
[BE] 입력값에 대한 유효성 검증

### DIFF
--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorController.java
@@ -5,11 +5,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/professors")
 @Tag(name = "Professor API", description = "교수 사용자 관련 API")
 @RequiredArgsConstructor
+@Validated
 public class ProfessorController {
 
     private final ProfessorService professorService;
@@ -33,7 +36,7 @@ public class ProfessorController {
             }
     )
     public ResponseEntity<Void> signUp(
-            @RequestParam("name") String name,
+            @RequestParam("name") @Pattern(regexp = "^[가-힣a-zA-Z]{1,20}$", message = "이름은 한글 또는 영문만 1~20자 입력 가능합니다.") String name,
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImageFile,
             HttpServletRequest request) {
         String oauthId = (String) request.getAttribute("oauthId");

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorService.java
@@ -1,6 +1,7 @@
 package com.softeer.reacton.domain.professor;
 
 import com.softeer.reacton.global.exception.BaseException;
+import com.softeer.reacton.global.exception.code.FileErrorCode;
 import com.softeer.reacton.global.exception.code.ProfessorErrorCode;
 import com.softeer.reacton.global.jwt.JwtTokenUtil;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -15,7 +17,14 @@ public class ProfessorService {
     private final ProfessorRepository professorRepository;
     private final JwtTokenUtil jwtTokenUtil;
 
+    private static final Set<String> ALLOWED_IMAGE_FILE_EXTENSIONS = Set.of("png", "jpg", "jpeg", "heic");
+    private static final long MAX_IMAGE_FILE_SIZE = 64 * 1024;
+
     public String signUp(String name, MultipartFile profileImageFile, String oauthId, String email, Boolean isSignedUp) {
+        if (profileImageFile != null && !profileImageFile.isEmpty()) {
+            validateProfileImage(profileImageFile);
+        }
+
         if (isSignedUp) {
             throw new BaseException(ProfessorErrorCode.ALREADY_REGISTERED_USER);
         }
@@ -44,4 +53,27 @@ public class ProfessorService {
 
         return jwtTokenUtil.createAuthAccessToken(oauthId, email);
     }
+
+    private void validateProfileImage(MultipartFile file) {
+        if (file.getSize() > MAX_IMAGE_FILE_SIZE) {
+            throw new BaseException(FileErrorCode.FILE_SIZE_EXCEEDED);
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename != null) {
+            String fileExtension = getFileExtension(originalFilename);
+            if (!ALLOWED_IMAGE_FILE_EXTENSIONS.contains(fileExtension.toLowerCase())) {
+                throw new BaseException(FileErrorCode.INVALID_FILE_TYPE);
+            }
+        }
+    }
+
+    private String getFileExtension(String filename) {
+        int lastDotIndex = filename.lastIndexOf(".");
+        if (lastDotIndex == -1) {
+            return ""; // 확장자가 없는 경우
+        }
+        return filename.substring(lastDotIndex + 1);
+    }
+
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorService.java
@@ -21,10 +21,6 @@ public class ProfessorService {
     private static final long MAX_IMAGE_FILE_SIZE = 64 * 1024;
 
     public String signUp(String name, MultipartFile profileImageFile, String oauthId, String email, Boolean isSignedUp) {
-        if (profileImageFile != null && !profileImageFile.isEmpty()) {
-            validateProfileImage(profileImageFile);
-        }
-
         if (isSignedUp) {
             throw new BaseException(ProfessorErrorCode.ALREADY_REGISTERED_USER);
         }
@@ -35,7 +31,8 @@ public class ProfessorService {
 
         // TODO: 현재 파일을 DB에 저장하지만, 추후 클라우드 스토리지(S3 등)에 업로드하도록 변경 예정
         byte[] imageBytes = null;
-        if (profileImageFile != null) {
+        if (profileImageFile != null && !profileImageFile.isEmpty()) {
+            validateProfileImage(profileImageFile);
             try {
                 imageBytes = profileImageFile.getBytes();
             } catch (IOException e) {

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/DTO/ExceptionResponse.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/DTO/ExceptionResponse.java
@@ -23,4 +23,11 @@ public class ExceptionResponse {
                 .message(errorCode.getMessage())
                 .build();
     }
+
+    public static ExceptionResponse of(ErrorCode errorCode, String customMessage) {
+        return ExceptionResponse.builder()
+                .errorCode(errorCode.getCode())
+                .message(customMessage)
+                .build();
+    }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/DTO/ExceptionResponse.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/DTO/ExceptionResponse.java
@@ -1,10 +1,12 @@
 package com.softeer.reacton.global.DTO;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.softeer.reacton.global.exception.code.ErrorCode;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@JsonPropertyOrder({"success", "errorCode", "message"})
 public class ExceptionResponse {
     private final boolean success;
     private final String errorCode;

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/Handler/GlobalExceptionHandler.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/Handler/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.softeer.reacton.global.exception.Handler;
 import com.softeer.reacton.global.exception.BaseException;
 import com.softeer.reacton.global.DTO.ExceptionResponse;
 import com.softeer.reacton.global.exception.code.GlobalErrorCode;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.ResponseEntity;
@@ -72,5 +73,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(GlobalErrorCode.WRONG_TYPE.getStatus())
                 .body(ExceptionResponse.of(GlobalErrorCode.WRONG_TYPE));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ExceptionResponse> handleConstraintViolationException(ConstraintViolationException e) {
+        log.warn(GlobalErrorCode.VALIDATION_FAILURE.getMessage());
+        return ResponseEntity
+                .status(GlobalErrorCode.VALIDATION_FAILURE.getStatus())
+                .body(ExceptionResponse.of(GlobalErrorCode.VALIDATION_FAILURE, e.getMessage()));
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/FileErrorCode.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/FileErrorCode.java
@@ -1,0 +1,20 @@
+package com.softeer.reacton.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FileErrorCode implements ErrorCode{
+    FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "업로드 가능한 최대 파일 크기는 64KB입니다."),
+    INVALID_FILE_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원되지 않는 파일 형식입니다. PNG, JPG, JPEG, HEIC 형식만 업로드할 수 있습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return name();
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthService.java
@@ -47,8 +47,9 @@ public class OAuthService {
 
     public OAuthLoginResult processOauthLogin(String providerName, String code) {
         log.debug("OAuth 로그인을 진행합니다.");
-      
-        if( code== null || code.isEmpty() ) {
+
+        if (code == null || code.isEmpty()) {
+            log.debug("OAuth 로그인을 진행하는 과정에서 발생한 에러입니다. : Parameter 'code' is empty.");
             throw new BaseException(GlobalErrorCode.MISSING_PARAMETER);
         }
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthService.java
@@ -66,7 +66,6 @@ public class OAuthService {
 
     private OAuthTokenResponse getAuthAccessTokenByOauth(String code, OAuthProvider provider) {
         MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
-        System.out.println(code);
         formData.add("code", code);
         formData.add("client_id", provider.getClientId());
         formData.add("client_secret", provider.getClientSecret());

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthService.java
@@ -42,6 +42,10 @@ public class OAuthService {
     }
 
     public OAuthLoginResult processOauthLogin(String providerName, String code) {
+        if( code== null || code.isEmpty() ) {
+            throw new BaseException(GlobalErrorCode.MISSING_PARAMETER);
+        }
+
         OAuthProvider provider = oauthConfig.getProvider(providerName);
 
         OAuthTokenResponse tokenResponse = getAuthAccessTokenByOauth(code, provider);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#55 [BE] 입력값에 대한 유효성 검증

## 📝 작업 내용

### 회원가입 입력값 유효성 검증
- 이름 : `@Validated`와 `@Pattern(regexp = "^[가-힣a-zA-Z]{1,20}$", message = "이름은 한글 또는 영문만 1~20자 입력 가능합니다.")`로 검증
    - ConstraintViolationException 예외를 GlobalExceptionHandler에서 처리
- 이미지 파일 : 지원하는 확장자(png, jpg, jpeg, heic)와 파일 크기(64KB) 검증
    - 파일 관련 에러를 관리하는 FileErrorCode 추가

### 기타 
- JSON 응답 필드 순서 고정

### 참고
> JWT 토큰과 관련해서 만료 시간을 한국 시간으로 변경해야 하는지 찾아보니 내부적으로는 GMT를 기준으로 동작하여 굳이 바꿀 필요 없을 것 같습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the sign-up process with stricter validation for user names, ensuring proper format.
  - Improved the image upload experience by enforcing file size and allowed format restrictions.
  - Upgraded error handling to deliver clearer, more informative feedback for validation issues.
  - Bolstered security during OAuth logins by validating input parameters and removing sensitive logging.
  - Introduced structured error responses for better clarity on issues encountered.
  - Added a new error code system for handling file-related issues during uploads.
  - Implemented a new handler for constraint violations to improve error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->