### PR TITLE
[BE] 교수 수업 생성/수정/삭제 API 

### DIFF
--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
@@ -67,8 +67,8 @@ public class Course {
         this.professor = professor;
     }
 
-    public static Course of(CourseCreateRequest request, int accessCode, Professor professor) {
-        return Course.builder()
+    public static Course create(CourseCreateRequest request, int accessCode, Professor professor) {
+        Course course = Course.builder()
                 .name(request.getName())
                 .courseCode(request.getCourseCode())
                 .capacity(request.getCapacity())
@@ -77,6 +77,9 @@ public class Course {
                 .accessCode(accessCode)
                 .professor(professor)
                 .build();
+
+        course.schedules = createScheduleList(request, course);
+        return course;
     }
 
     public void update(CourseCreateRequest request) {

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
@@ -2,9 +2,12 @@ package com.softeer.reacton.domain.course;
 
 import com.softeer.reacton.domain.course.enums.CourseType;
 import com.softeer.reacton.domain.professor.Professor;
+import com.softeer.reacton.domain.schedule.Schedule;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "course")
@@ -44,4 +47,6 @@ public class Course {
     @JoinColumn(name = "professor_id", nullable = false)
     private Professor professor; // 교수 정보 (외래 키)
 
+    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Schedule> schedules;
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
@@ -37,7 +37,7 @@ public class Course {
     @Column(nullable = false, length = 20)
     private CourseType type; // 수업 종류 (전공, 교양, 기타)
 
-    @Column(nullable = false, unique = true, length = 10)
+    @Column(nullable = false, unique = true)
     private int accessCode;
 
     @Column(nullable = false)

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
@@ -48,6 +48,31 @@ public class Course {
     @JoinColumn(name = "professor_id", nullable = false)
     private Professor professor; // 교수 정보 (외래 키)
 
+    @Setter
     @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Schedule> schedules;
+
+    @Builder
+    private Course(String name, String courseCode, int capacity, String university, CourseType type, int accessCode, Professor professor) {
+        this.name = name;
+        this.courseCode = courseCode;
+        this.capacity = capacity;
+        this.university = university;
+        this.type = type;
+        this.accessCode = accessCode;
+        this.isActive = false;
+        this.professor = professor;
+    }
+
+    public static Course of(CourseCreateRequest request, int accessCode, Professor professor) {
+        return Course.builder()
+                .name(request.getName())
+                .courseCode(request.getCourseCode())
+                .capacity(request.getCapacity())
+                .university(request.getUniversity())
+                .type(request.getType())
+                .accessCode(accessCode)
+                .professor(professor)
+                .build();
+    }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
@@ -1,11 +1,11 @@
 package com.softeer.reacton.domain.course;
 
+import com.softeer.reacton.domain.course.dto.CourseCreateRequest;
 import com.softeer.reacton.domain.course.enums.CourseType;
 import com.softeer.reacton.domain.professor.Professor;
 import com.softeer.reacton.domain.schedule.Schedule;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -16,6 +16,7 @@ public class Course {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
     private Long id;
 
     @Column(nullable = false, length = 100)
@@ -35,7 +36,7 @@ public class Course {
     private CourseType type; // 수업 종류 (전공, 교양, 기타)
 
     @Column(nullable = false, unique = true, length = 10)
-    private String accessCode;
+    private int accessCode;
 
     @Column(nullable = false)
     private boolean isActive;

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
@@ -34,8 +34,8 @@ public class Course {
     @Column(nullable = false, unique = true, length = 10)
     private String accessCode;
 
-    @Column(nullable = false, length = 20)
-    private String status; // 상태 (진행중, 종료됨 등)
+    @Column(nullable = false)
+    private boolean isActive;
 
     @Column(length = 512)
     private String fileUrl; // 강의 자료 URL

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
@@ -1,5 +1,6 @@
 package com.softeer.reacton.domain.course;
 
+import com.softeer.reacton.domain.course.enums.CourseType;
 import com.softeer.reacton.domain.professor.Professor;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -26,8 +27,9 @@ public class Course {
     @Column(nullable = false, length = 100)
     private String university;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    private String type; // 수업 종류 (전공, 교양, 기타)
+    private CourseType type; // 수업 종류 (전공, 교양, 기타)
 
     @Column(nullable = false, unique = true, length = 10)
     private String accessCode;

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
@@ -1,6 +1,6 @@
 package com.softeer.reacton.domain.course;
 
-import com.softeer.reacton.domain.course.dto.CourseCreateRequest;
+import com.softeer.reacton.domain.course.dto.CourseRequest;
 import com.softeer.reacton.domain.course.enums.CourseType;
 import com.softeer.reacton.domain.professor.Professor;
 import com.softeer.reacton.domain.schedule.Schedule;
@@ -67,7 +67,7 @@ public class Course {
         this.professor = professor;
     }
 
-    public static Course create(CourseCreateRequest request, int accessCode, Professor professor) {
+    public static Course create(CourseRequest request, int accessCode, Professor professor) {
         Course course = Course.builder()
                 .name(request.getName())
                 .courseCode(request.getCourseCode())
@@ -82,7 +82,7 @@ public class Course {
         return course;
     }
 
-    public void update(CourseCreateRequest request) {
+    public void update(CourseRequest request) {
         this.name = request.getName();
         this.courseCode = request.getCourseCode();
         this.capacity = request.getCapacity();
@@ -93,7 +93,7 @@ public class Course {
         this.schedules.addAll(createScheduleList(request, this));
     }
 
-    private static List<Schedule> createScheduleList(CourseCreateRequest request, Course course) {
+    private static List<Schedule> createScheduleList(CourseRequest request, Course course) {
         return request.getSchedules().stream()
                 .map(scheduleRequest -> Schedule.builder()
                         .day(scheduleRequest.getDay())

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
@@ -1,6 +1,6 @@
 package com.softeer.reacton.domain.course;
 
-import com.softeer.reacton.domain.course.dto.CourseCreateRequest;
+import com.softeer.reacton.domain.course.dto.CourseRequest;
 import com.softeer.reacton.global.dto.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -29,10 +29,10 @@ public class ProfessorCourseController {
             description = "수업 데이터를 받아 데이터베이스 저장하고 courseId를 반환합니다.",
             responses = {@ApiResponse(responseCode = "201", description = "수업이 생성되었습니다.")}
     )
-    public ResponseEntity<SuccessResponse<Map<String, String>>> createCourse(HttpServletRequest request, @RequestBody CourseCreateRequest courseCreateRequest) {
+    public ResponseEntity<SuccessResponse<Map<String, String>>> createCourse(HttpServletRequest request, @RequestBody CourseRequest courseRequest) {
         String oauthId = (String) request.getAttribute("oauthId");
 
-        long courseId = professorCourseService.createCourse(oauthId, courseCreateRequest);
+        long courseId = professorCourseService.createCourse(oauthId, courseRequest);
 
         Map<String, String> response = new HashMap<>();
         response.put("courseId", String.valueOf(courseId));
@@ -48,9 +48,9 @@ public class ProfessorCourseController {
             description = "수업 데이터를 기존 데이터에 업데이트하고 courseId를 반환합니다.",
             responses = {@ApiResponse(responseCode = "200", description = "수업이 수정되었습니다.")}
     )
-    public ResponseEntity<SuccessResponse<Map<String, String>>> updateCourse(HttpServletRequest request, @PathVariable(value = "courseId") long courseId, @RequestBody CourseCreateRequest courseCreateRequest) {
+    public ResponseEntity<SuccessResponse<Map<String, String>>> updateCourse(HttpServletRequest request, @PathVariable(value = "courseId") long courseId, @RequestBody CourseRequest courseRequest) {
         String oauthId = (String) request.getAttribute("oauthId");
-        professorCourseService.updateCourse(oauthId, courseId, courseCreateRequest);
+        professorCourseService.updateCourse(oauthId, courseId, courseRequest);
 
         Map<String, String> response = new HashMap<>();
         response.put("courseId", String.valueOf(courseId));

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
@@ -10,10 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,5 +41,24 @@ public class ProfessorCourseController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(SuccessResponse.of("수업이 생성되었습니다.", response));
+    }
+
+    @PutMapping("/{courseId}")
+    @Operation(
+            summary = "수업 수정 요청",
+            description = "수업 데이터를 기존 데이터에 업데이트하고 courseId를 반환합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "수업이 수정되었습니다.")}
+    )
+    public ResponseEntity<SuccessResponse<Map<String, String>>> updateCourse(HttpServletRequest request, @PathVariable(value = "courseId") long courseId, @RequestBody CourseCreateRequest courseCreateRequest) {
+        String oauthId = (String) request.getAttribute("oauthId");
+        professorCourseService.updateCourse(oauthId, courseId, courseCreateRequest);
+        log.info("수업을 수정하고 DB에 저장했습니다. : courseId = {}", courseId);
+
+        Map<String, String> response = new HashMap<>();
+        response.put("courseId", String.valueOf(courseId));
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.of("수업이 수정되었습니다.", response));
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -29,7 +30,7 @@ public class ProfessorCourseController {
             description = "수업 데이터를 받아 데이터베이스 저장하고 courseId를 반환합니다.",
             responses = {@ApiResponse(responseCode = "201", description = "수업이 생성되었습니다.")}
     )
-    public ResponseEntity<SuccessResponse<Map<String, String>>> createCourse(HttpServletRequest request, @RequestBody CourseRequest courseRequest) {
+    public ResponseEntity<SuccessResponse<Map<String, String>>> createCourse(HttpServletRequest request, @RequestBody @Valid CourseRequest courseRequest) {
         String oauthId = (String) request.getAttribute("oauthId");
 
         long courseId = professorCourseService.createCourse(oauthId, courseRequest);
@@ -48,7 +49,10 @@ public class ProfessorCourseController {
             description = "수업 데이터를 기존 데이터에 업데이트하고 courseId를 반환합니다.",
             responses = {@ApiResponse(responseCode = "200", description = "수업이 수정되었습니다.")}
     )
-    public ResponseEntity<SuccessResponse<Map<String, String>>> updateCourse(HttpServletRequest request, @PathVariable(value = "courseId") long courseId, @RequestBody CourseRequest courseRequest) {
+    public ResponseEntity<SuccessResponse<Map<String, String>>> updateCourse(
+            HttpServletRequest request,
+            @PathVariable(value = "courseId") long courseId,
+            @RequestBody @Valid CourseRequest courseRequest) {
         String oauthId = (String) request.getAttribute("oauthId");
         professorCourseService.updateCourse(oauthId, courseId, courseRequest);
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
@@ -33,7 +33,6 @@ public class ProfessorCourseController {
         String oauthId = (String) request.getAttribute("oauthId");
 
         long courseId = professorCourseService.createCourse(oauthId, courseCreateRequest);
-        log.info("수업을 생성하고 DB에 저장했습니다. : courseId = {}", courseId);
 
         Map<String, String> response = new HashMap<>();
         response.put("courseId", String.valueOf(courseId));
@@ -52,7 +51,6 @@ public class ProfessorCourseController {
     public ResponseEntity<SuccessResponse<Map<String, String>>> updateCourse(HttpServletRequest request, @PathVariable(value = "courseId") long courseId, @RequestBody CourseCreateRequest courseCreateRequest) {
         String oauthId = (String) request.getAttribute("oauthId");
         professorCourseService.updateCourse(oauthId, courseId, courseCreateRequest);
-        log.info("수업을 수정하고 DB에 저장했습니다. : courseId = {}", courseId);
 
         Map<String, String> response = new HashMap<>();
         response.put("courseId", String.valueOf(courseId));

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
@@ -1,7 +1,48 @@
 package com.softeer.reacton.domain.course;
 
+import com.softeer.reacton.domain.course.dto.CourseCreateRequest;
+import com.softeer.reacton.global.dto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
 @RestController
+@RequestMapping("/professors/courses")
+@Tag(name = "Professor Course API", description = "교수 수업 관련 API")
+@RequiredArgsConstructor
 public class ProfessorCourseController {
+    private final ProfessorCourseService professorCourseService;
+
+    @PostMapping
+    @Operation(
+            summary = "수업 생성 요청",
+            description = "수업 데이터를 받아 데이터베이스 저장하고 courseId를 반환합니다.",
+            responses = {@ApiResponse(responseCode = "201", description = "수업이 생성되었습니다.")}
+    )
+    public ResponseEntity<SuccessResponse<Map<String, String>>> createCourse(HttpServletRequest request, @RequestBody CourseCreateRequest courseCreateRequest) {
+        String oauthId = (String) request.getAttribute("oauthId");
+
+        long courseId = professorCourseService.createCourse(oauthId, courseCreateRequest);
+        log.info("수업을 생성하고 DB에 저장했습니다. : courseId = {}", courseId);
+
+        Map<String, String> response = new HashMap<>();
+        response.put("courseId", String.valueOf(courseId));
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(SuccessResponse.of("수업이 생성되었습니다.", response));
+    }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
@@ -59,4 +59,19 @@ public class ProfessorCourseController {
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.of("수업이 수정되었습니다.", response));
     }
+
+    @DeleteMapping("/{courseId}")
+    @Operation(
+            summary = "수업 삭제 요청",
+            description = "courseId에 해당하는 수업을 삭제합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "수업이 삭제되었습니다.")}
+    )
+    public ResponseEntity<SuccessResponse<Map<String, String>>> deleteCourse(HttpServletRequest request, @PathVariable(value = "courseId") long courseId) {
+        String oauthId = (String) request.getAttribute("oauthId");
+        professorCourseService.deleteCourse(oauthId, courseId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.of("수업이 삭제되었습니다", null));
+    }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
@@ -68,14 +68,12 @@ public class ProfessorCourseController {
     @Operation(
             summary = "수업 삭제 요청",
             description = "courseId에 해당하는 수업을 삭제합니다.",
-            responses = {@ApiResponse(responseCode = "200", description = "수업이 삭제되었습니다.")}
+            responses = {@ApiResponse(responseCode = "204", description = "수업이 삭제되었습니다.")}
     )
-    public ResponseEntity<SuccessResponse<Map<String, String>>> deleteCourse(HttpServletRequest request, @PathVariable(value = "courseId") long courseId) {
+    public ResponseEntity<Void> deleteCourse(HttpServletRequest request, @PathVariable(value = "courseId") long courseId) {
         String oauthId = (String) request.getAttribute("oauthId");
         professorCourseService.deleteCourse(oauthId, courseId);
 
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(SuccessResponse.of("수업이 삭제되었습니다", null));
+        return ResponseEntity.noContent().build();
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -30,18 +30,7 @@ public class ProfessorCourseService {
         int accessCode = 100000 + secureRandom.nextInt(900000);
         log.debug("입장코드용 랜덤한 6자리 숫자를 생성합니다 : accessCode = {}", accessCode);
 
-        Course course = Course.of(request, accessCode, professor);
-        List<Schedule> schedules = request.getSchedules().stream()
-                .map(scheduleRequest ->
-                        Schedule.builder()
-                                .day(scheduleRequest.getDay())
-                                .startTime(TimeUtil.parseTime(scheduleRequest.getStartTime()))
-                                .endTime(TimeUtil.parseTime(scheduleRequest.getEndTime()))
-                                .course(course)
-                                .build())
-                .collect(Collectors.toList());
-        course.setSchedules(schedules);
-
+        Course course = Course.create(request, accessCode, professor);
         return courseRepository.save(course).getId();
     }
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -20,6 +20,7 @@ public class ProfessorCourseService {
     private final ProfessorRepository professorRepository;
     private final CourseRepository courseRepository;
 
+    @Transactional
     public long createCourse(String oauthId, CourseCreateRequest request) {
         log.debug("수업을 생성합니다.");
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -1,7 +1,49 @@
 package com.softeer.reacton.domain.course;
 
+import com.softeer.reacton.domain.course.dto.CourseCreateRequest;
+import com.softeer.reacton.domain.professor.Professor;
+import com.softeer.reacton.domain.professor.ProfessorRepository;
+import com.softeer.reacton.domain.schedule.Schedule;
+import com.softeer.reacton.global.exception.BaseException;
+import com.softeer.reacton.global.exception.code.ProfessorErrorCode;
+import com.softeer.reacton.global.util.TimeUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class ProfessorCourseService {
+    private final ProfessorRepository professorRepository;
+    private final CourseRepository courseRepository;
+
+    public long createCourse(String oauthId, CourseCreateRequest request) {
+        log.debug("수업을 생성합니다.");
+
+        Professor professor = professorRepository.findByOauthId(oauthId)
+                .orElseThrow(() -> new BaseException(ProfessorErrorCode.PROFESSOR_NOT_FOUND));
+
+        SecureRandom secureRandom = new SecureRandom();
+        int accessCode = 100000 + secureRandom.nextInt(900000);
+        log.debug("입장코드용 랜덤한 6자리 숫자를 생성합니다 : accessCode = {}", accessCode);
+
+        Course course = Course.of(request, accessCode, professor);
+        List<Schedule> schedules = request.getSchedules().stream()
+                .map(scheduleRequest ->
+                        Schedule.builder()
+                                .day(scheduleRequest.getDay())
+                                .startTime(TimeUtil.parseTime(scheduleRequest.getStartTime()))
+                                .endTime(TimeUtil.parseTime(scheduleRequest.getEndTime()))
+                                .course(course)
+                                .build())
+                .collect(Collectors.toList());
+        course.setSchedules(schedules);
+
+        return courseRepository.save(course).getId();
+    }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -39,18 +39,36 @@ public class ProfessorCourseService {
     public void updateCourse(String oauthId, long courseId, CourseCreateRequest request) {
         log.debug("수업 데이터를 업데이트합니다. : courseId = {}", courseId);
 
+        Course course = findCourseByProfessor(oauthId, courseId);
+
+        course.update(request);
+
+        log.info("수업 업데이트가 완료되었습니다. : courseId = {}", courseId);
+    }
+
+    @Transactional
+    public void deleteCourse(String oauthId, long courseId) {
+        log.debug("수업을 삭제합니다. : courseId = {}", courseId);
+
+        Course course = findCourseByProfessor(oauthId, courseId);
+
+        courseRepository.delete(course);
+        courseRepository.flush();
+
+        log.info("수업이 삭제되었습니다. : courseId = {}", courseId);
+    }
+
+    private Course findCourseByProfessor(String oauthId, long courseId) {
         Professor professor = professorRepository.findByOauthId(oauthId)
                 .orElseThrow(() -> new BaseException(ProfessorErrorCode.PROFESSOR_NOT_FOUND));
 
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new BaseException(CourseErrorCode.COURSE_NOT_FOUND));
 
-        if (!course.getProfessor().equals(professor)) {
+        if (!course.getProfessor().getId().equals(professor.getId())) {
             throw new BaseException(CourseErrorCode.UNAUTHORIZED_PROFESSOR);
         }
 
-        course.update(request);
-
-        log.info("수업 업데이트 완료: courseId = {}", courseId);
+        return course;
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -1,6 +1,6 @@
 package com.softeer.reacton.domain.course;
 
-import com.softeer.reacton.domain.course.dto.CourseCreateRequest;
+import com.softeer.reacton.domain.course.dto.CourseRequest;
 import com.softeer.reacton.domain.professor.Professor;
 import com.softeer.reacton.domain.professor.ProfessorRepository;
 import com.softeer.reacton.global.exception.BaseException;
@@ -21,7 +21,7 @@ public class ProfessorCourseService {
     private final CourseRepository courseRepository;
 
     @Transactional
-    public long createCourse(String oauthId, CourseCreateRequest request) {
+    public long createCourse(String oauthId, CourseRequest request) {
         log.debug("수업을 생성합니다.");
 
         Professor professor = professorRepository.findByOauthId(oauthId)
@@ -39,7 +39,7 @@ public class ProfessorCourseService {
     }
 
     @Transactional
-    public void updateCourse(String oauthId, long courseId, CourseCreateRequest request) {
+    public void updateCourse(String oauthId, long courseId, CourseRequest request) {
         log.debug("수업 데이터를 업데이트합니다. : courseId = {}", courseId);
 
         Course course = findCourseByProfessor(oauthId, courseId);

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -23,6 +23,10 @@ public class ProfessorCourseService {
     @Transactional
     public long createCourse(String oauthId, CourseRequest request) {
         log.debug("수업을 생성합니다.");
+        if (request == null) {
+            log.warn("수업 생성 요청 데이터가 null입니다. : 'request' is null.");
+            throw new BaseException(CourseErrorCode.COURSE_REQUEST_IS_NULL);
+        }
 
         Professor professor = professorRepository.findByOauthId(oauthId)
                 .orElseThrow(() -> new BaseException(ProfessorErrorCode.PROFESSOR_NOT_FOUND));
@@ -41,6 +45,11 @@ public class ProfessorCourseService {
     @Transactional
     public void updateCourse(String oauthId, long courseId, CourseRequest request) {
         log.debug("수업 데이터를 업데이트합니다. : courseId = {}", courseId);
+
+        if (request == null) {
+            log.warn("수업 수정 요청 데이터가 null입니다. : 'request' is null.");
+            throw new BaseException(CourseErrorCode.COURSE_REQUEST_IS_NULL);
+        }
 
         Course course = findCourseByProfessor(oauthId, courseId);
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -32,7 +32,10 @@ public class ProfessorCourseService {
         log.debug("입장코드용 랜덤한 6자리 숫자를 생성합니다 : accessCode = {}", accessCode);
 
         Course course = Course.create(request, accessCode, professor);
-        return courseRepository.save(course).getId();
+        long courseId = courseRepository.save(course).getId();
+        log.info("수업이 생성되었습니다. : courseId = {}", courseId);
+
+        return courseId;
     }
 
     @Transactional

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/dto/CourseCreateRequest.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/dto/CourseCreateRequest.java
@@ -1,0 +1,26 @@
+package com.softeer.reacton.domain.course.dto;
+
+import com.softeer.reacton.domain.course.enums.CourseType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CourseCreateRequest {
+    private String name;
+    private String courseCode;
+    private int capacity;
+    private String university;
+    private CourseType type;
+    private List<ScheduleRequest> schedules;
+
+    @Getter
+    @NoArgsConstructor
+    public static class ScheduleRequest {
+        private String day;
+        private String startTime;
+        private String endTime;
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/dto/CourseRequest.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/dto/CourseRequest.java
@@ -1,6 +1,11 @@
 package com.softeer.reacton.domain.course.dto;
 
 import com.softeer.reacton.domain.course.enums.CourseType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,18 +14,30 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class CourseRequest {
+    @NotBlank(message = "수업 이름이 입력되지 않았습니다.")
     private String name;
+    @NotBlank(message = "학수번호가 입력되지 않았습니다.")
     private String courseCode;
+    @Positive(message = "수업 정원이 입력되지 않았습니다.")
     private int capacity;
+    @NotBlank(message = "대학 이름이 입력되지 않았습니다.")
     private String university;
+    @NotNull(message = "수업 종류가 선택되지 않았습니다.")
     private CourseType type;
+    @Valid
     private List<ScheduleRequest> schedules;
 
     @Getter
     @NoArgsConstructor
     public static class ScheduleRequest {
+        @NotBlank(message = "요일이 필요합니다.")
+        @Pattern(regexp = "^(월|화|수|목|금|토|일)$", message = "요일 값이 올바르지 않습니다. (월~일)")
         private String day;
+        @NotBlank(message = "시작 시간이 필요합니다.")
+        @Pattern(regexp = "^([01]?[0-9]|2[0-3]):[0-5][0-9]$", message = "시간 형식이 올바르지 않습니다. (HH:mm)")
         private String startTime;
+        @NotBlank(message = "종료 시간이 필요합니다.")
+        @Pattern(regexp = "^([01]?[0-9]|2[0-3]):[0-5][0-9]$", message = "시간 형식이 올바르지 않습니다. (HH:mm)")
         private String endTime;
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/dto/CourseRequest.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/dto/CourseRequest.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
-public class CourseCreateRequest {
+public class CourseRequest {
     private String name;
     private String courseCode;
     private int capacity;

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/dto/CourseRequest.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/dto/CourseRequest.java
@@ -1,11 +1,9 @@
 package com.softeer.reacton.domain.course.dto;
 
 import com.softeer.reacton.domain.course.enums.CourseType;
+import com.softeer.reacton.global.util.TimeUtil;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,14 +14,19 @@ import java.util.List;
 public class CourseRequest {
     @NotBlank(message = "수업 이름이 입력되지 않았습니다.")
     private String name;
+
     @NotBlank(message = "학수번호가 입력되지 않았습니다.")
     private String courseCode;
+
     @Positive(message = "수업 정원이 입력되지 않았습니다.")
     private int capacity;
+
     @NotBlank(message = "대학 이름이 입력되지 않았습니다.")
     private String university;
+
     @NotNull(message = "수업 종류가 선택되지 않았습니다.")
     private CourseType type;
+
     @Valid
     private List<ScheduleRequest> schedules;
 
@@ -33,11 +36,18 @@ public class CourseRequest {
         @NotBlank(message = "요일이 필요합니다.")
         @Pattern(regexp = "^(월|화|수|목|금|토|일)$", message = "요일 값이 올바르지 않습니다. (월~일)")
         private String day;
+
         @NotBlank(message = "시작 시간이 필요합니다.")
         @Pattern(regexp = "^([01]?[0-9]|2[0-3]):[0-5][0-9]$", message = "시간 형식이 올바르지 않습니다. (HH:mm)")
         private String startTime;
+
         @NotBlank(message = "종료 시간이 필요합니다.")
         @Pattern(regexp = "^([01]?[0-9]|2[0-3]):[0-5][0-9]$", message = "시간 형식이 올바르지 않습니다. (HH:mm)")
         private String endTime;
+
+        @AssertTrue(message = "종료 시간은 시작 시간보다 늦어야 합니다.")
+        public boolean isEndTimeValid() {
+            return TimeUtil.isEndTimeAfterStartTime(startTime, endTime);
+        }
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/enums/CourseType.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/enums/CourseType.java
@@ -1,0 +1,16 @@
+package com.softeer.reacton.domain.course.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum CourseType {
+    MAJOR("전공"),
+    GENERAL("교양"),
+    OTHER("기타");
+
+    private final String description;
+
+    CourseType(String description) {
+        this.description = description;
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/Professor.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/Professor.java
@@ -19,7 +19,7 @@ public class Professor {
     @Column(nullable = false, unique = true, length = 100)
     private String email;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false, length = 60)
     private String name;
 
     @Column(unique = true, length = 255)

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/schedule/Schedule.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/schedule/Schedule.java
@@ -1,0 +1,33 @@
+package com.softeer.reacton.domain.schedule;
+
+import com.softeer.reacton.domain.course.Course;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "schedule")
+@Entity
+public class Schedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 3)
+    private String day;
+
+    @Column(nullable = false)
+    private LocalTime startTime;
+
+    @Column(nullable = false)
+    private LocalTime endTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/schedule/Schedule.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/schedule/Schedule.java
@@ -2,9 +2,7 @@ package com.softeer.reacton.domain.schedule;
 
 import com.softeer.reacton.domain.course.Course;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalTime;
 
@@ -27,7 +25,16 @@ public class Schedule {
     @Column(nullable = false)
     private LocalTime endTime;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "course_id", nullable = false)
     private Course course;
+
+    @Builder
+    public Schedule(String day, LocalTime startTime, LocalTime endTime, Course course) {
+        this.day = day;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.course = course;
+    }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/schedule/ScheduleRepository.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/schedule/ScheduleRepository.java
@@ -1,0 +1,6 @@
+package com.softeer.reacton.domain.schedule;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/dto/ExceptionResponse.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/dto/ExceptionResponse.java
@@ -1,4 +1,4 @@
-package com.softeer.reacton.global.DTO;
+package com.softeer.reacton.global.dto;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.softeer.reacton.global.exception.code.ErrorCode;

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/dto/SuccessResponse.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/dto/SuccessResponse.java
@@ -1,4 +1,4 @@
-package com.softeer.reacton.global.DTO;
+package com.softeer.reacton.global.dto;
 
 import lombok.Getter;
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/dto/SuccessResponse.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/dto/SuccessResponse.java
@@ -1,10 +1,29 @@
 package com.softeer.reacton.global.dto;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Map;
+
 @Getter
+@JsonPropertyOrder({"success", "message", "data"})
 public class SuccessResponse<T> {
-    private boolean success;
-    private String message;
-    private T data;
+    private final boolean success;
+    private final String message;
+    private final T data;
+
+    @Builder
+    public SuccessResponse(String message, T data) {
+        this.success = true;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static SuccessResponse<Map<String, String>> of(String message, Map<String, String> data) {
+        return SuccessResponse.<Map<String, String>>builder()
+                .message(message)
+                .data(data)
+                .build();
+    }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/Controller/CustomErrorController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/Controller/CustomErrorController.java
@@ -1,7 +1,7 @@
 package com.softeer.reacton.global.exception.Controller;
 
 import com.softeer.reacton.global.exception.code.GlobalErrorCode;
-import com.softeer.reacton.global.DTO.ExceptionResponse;
+import com.softeer.reacton.global.dto.ExceptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/Handler/GlobalExceptionHandler.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/Handler/GlobalExceptionHandler.java
@@ -1,7 +1,7 @@
 package com.softeer.reacton.global.exception.Handler;
 
 import com.softeer.reacton.global.exception.BaseException;
-import com.softeer.reacton.global.DTO.ExceptionResponse;
+import com.softeer.reacton.global.dto.ExceptionResponse;
 import com.softeer.reacton.global.exception.code.GlobalErrorCode;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.log4j.Log4j2;

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/Handler/GlobalExceptionHandler.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/Handler/GlobalExceptionHandler.java
@@ -56,7 +56,7 @@ public class GlobalExceptionHandler {
         log.warn(GlobalErrorCode.VALIDATION_FAILURE.getMessage());
         return ResponseEntity
                 .status(GlobalErrorCode.VALIDATION_FAILURE.getStatus())
-                .body(ExceptionResponse.of(GlobalErrorCode.VALIDATION_FAILURE));
+                .body(ExceptionResponse.of(GlobalErrorCode.VALIDATION_FAILURE, e.getBindingResult().getFieldErrors().get(0).getDefaultMessage()));
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/CourseErrorCode.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/CourseErrorCode.java
@@ -6,9 +6,10 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum CourseErrorCode implements ErrorCode{
+public enum CourseErrorCode implements ErrorCode {
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 강의 정보를 찾을 수 없습니다."),
-    UNAUTHORIZED_PROFESSOR(HttpStatus.FORBIDDEN, "이 강의를 수정할 권한이 없습니다.");
+    UNAUTHORIZED_PROFESSOR(HttpStatus.FORBIDDEN, "이 강의를 수정할 권한이 없습니다."),
+    COURSE_REQUEST_IS_NULL(HttpStatus.BAD_REQUEST, "수업 요청 정보가 입력되지 않았습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/CourseErrorCode.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/CourseErrorCode.java
@@ -1,0 +1,20 @@
+package com.softeer.reacton.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CourseErrorCode implements ErrorCode{
+    COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 강의 정보를 찾을 수 없습니다."),
+    UNAUTHORIZED_PROFESSOR(HttpStatus.FORBIDDEN, "이 강의를 수정할 권한이 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return name();
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/ProfessorErrorCode.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/ProfessorErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ProfessorErrorCode implements ErrorCode {
     ALREADY_REGISTERED_USER(HttpStatus.CONFLICT, "이미 가입된 사용자입니다."),
-    IMAGE_PROCESSING_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 변환 중 오류가 발생했습니다.");
+    IMAGE_PROCESSING_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 변환 중 오류가 발생했습니다."),
+    PROFESSOR_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 교수 정보가 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/TimeUtilErrorCode.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/TimeUtilErrorCode.java
@@ -1,0 +1,21 @@
+package com.softeer.reacton.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TimeUtilErrorCode implements ErrorCode {
+    NULL_TIME_STRING(HttpStatus.BAD_REQUEST, "시간 문자열은 null일 수 없습니다."),
+    INVALID_TIME_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 시간 형식입니다. 올바른 형식: HH:mm"),
+    NULL_LOCAL_TIME(HttpStatus.BAD_REQUEST, "LocalTime 객체는 null일 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return name();
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/jwt/JwtAuthenticationFilter.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/jwt/JwtAuthenticationFilter.java
@@ -2,7 +2,7 @@ package com.softeer.reacton.global.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.softeer.reacton.global.exception.BaseException;
-import com.softeer.reacton.global.DTO.ExceptionResponse;
+import com.softeer.reacton.global.dto.ExceptionResponse;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/util/TimeUtil.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/util/TimeUtil.java
@@ -34,12 +34,8 @@ public class TimeUtil {
     }
 
     public static boolean isEndTimeAfterStartTime(String startTime, String endTime) {
-        try {
-            LocalTime start = LocalTime.parse(startTime, FORMATTER);
-            LocalTime end = LocalTime.parse(endTime, FORMATTER);
-            return end.isAfter(start);
-        } catch (Exception e) {
-            return false;
-        }
+        LocalTime start = parseTime(startTime);
+        LocalTime end = parseTime(endTime);
+        return end.isAfter(start);
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/util/TimeUtil.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/util/TimeUtil.java
@@ -1,0 +1,16 @@
+package com.softeer.reacton.global.util;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+public class TimeUtil {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    public static LocalTime parseTime(String time) {
+        return LocalTime.parse(time, FORMATTER);
+    }
+
+    public static String formatTime(LocalTime time) {
+        return time.format(FORMATTER);
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/util/TimeUtil.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/util/TimeUtil.java
@@ -1,16 +1,35 @@
 package com.softeer.reacton.global.util;
 
+import com.softeer.reacton.global.exception.BaseException;
+import com.softeer.reacton.global.exception.code.TimeUtilErrorCode;
+import lombok.extern.slf4j.Slf4j;
+
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
+@Slf4j
 public class TimeUtil {
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
     public static LocalTime parseTime(String time) {
-        return LocalTime.parse(time, FORMATTER);
+        if (time == null || time.isBlank()) {
+            log.debug("문자열을 LocalTime으로 변환하는 과정에서 오류가 발생했습니다. : 'time' is null or empty.");
+            throw new BaseException(TimeUtilErrorCode.NULL_TIME_STRING);
+        }
+        try {
+            return LocalTime.parse(time, FORMATTER);
+        } catch (DateTimeParseException e) {
+            log.debug("문자열을 LocalTime으로 변환하는 과정에서 오류가 발생했습니다. : Failed to parse time. time={}", time);
+            throw new BaseException(TimeUtilErrorCode.INVALID_TIME_FORMAT);
+        }
     }
 
     public static String formatTime(LocalTime time) {
+        if (time == null) {
+            log.debug("LocalTime을 문자열로 바꾸는 과정에서 발생한 에러입니다. : 'time' is null.");
+            throw new BaseException(TimeUtilErrorCode.NULL_LOCAL_TIME);
+        }
         return time.format(FORMATTER);
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/util/TimeUtil.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/util/TimeUtil.java
@@ -32,4 +32,14 @@ public class TimeUtil {
         }
         return time.format(FORMATTER);
     }
+
+    public static boolean isEndTimeAfterStartTime(String startTime, String endTime) {
+        try {
+            LocalTime start = LocalTime.parse(startTime, FORMATTER);
+            LocalTime end = LocalTime.parse(endTime, FORMATTER);
+            return end.isAfter(start);
+        } catch (Exception e) {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
## `[FE/BE] PR 제목`을 꼭 써주세요 

## #️⃣ 연관된 이슈

#61 [BE] 교수 수업 생성/수정/삭제 API

## 📝 작업 내용

### 1️⃣ 수업 생성 API 구현 
1. oauthId로 사용자 정보 조회
2. RandomSecure로 숫자 6자리 입장 코드 생성
3. 로그인한 사용자의 수업 생성
4. DB에 저장 후 courseId 응답으로 반환

### 2️⃣ 수업 수정 API 구현
- 수업 생성 로직에서 입장 코드 생성 과정만 제외

### 3️⃣ 수업 삭제 API 구현
1. oauthId로 사용자 정보 조회
2. courseId에 해당하는 수업의 사용자 정보와 로그인한 사용자 정보 일치 여부 확인
3. 수업 삭제

### 추후 논의해볼 사항
- RandomSecure로 6자리 숫자로만 입장 코드를 생성할 경우 중복이 발생할 수도 있습니다. 중복이 발생하면 재생성하는 과정이나 입장 코드 자체를 늘리는 쪽도 고려해봐야 할 것 같습니다. 
- 매번 HttpRequestServlet의 oauthId를 가져오는 코드가 지저분해보여서 이를 줄일 수 있는 방법을 모색해보겠습니다..! ArgumentResolver를 사용하는 방법이 있다고 하는데 다음 이슈에서 적용해 볼 예정입니다. 
- 우선 수업을 생성하거나 수정하면 courseId 값을 응답에 넣어서 보냈습니다. 프론트분들과 상의해서 다른 응답이 필요하면 수정하겠습니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Professors can now create, update, and delete courses with a streamlined process.
  - Courses support detailed scheduling and standardized course type options.
  - Enhanced error messaging provides clearer feedback on course access and modification issues.
  - New utility methods for handling time formatting and validation.
  - Comprehensive error handling for course and time-related operations.
  - New response structure for successful API operations.

- **Refactor**
  - Improved data consistency and validation for course information.
  - Standardized time handling for schedule formatting.
  - Extended professor profile support to accommodate longer names.
  - Updated package naming conventions for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->