### PR TITLE
[FE] 학생 강의 페이지 레이아웃 구현 

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -10,7 +10,7 @@ import ProfessorProfile from './pages/professor/profile';
 import ProfessorCourse from './pages/professor/course';
 import ProfessorClassRoom from './pages/professor/course/classroom';
 import StudentHome from './pages/student/home/StudentHome';
-import StudentCourse from './pages/student/course';
+import StudentCourse from './pages/student/course/StudentCourse';
 import ProfessorLayout from './pages/professor/ProfessorLayout';
 
 function App() {

--- a/front-end/src/pages/student/course/StudentCourse.module.css
+++ b/front-end/src/pages/student/course/StudentCourse.module.css
@@ -1,0 +1,115 @@
+.couseLayout {
+  width: 100%;
+  height: 100vh;
+}
+
+.headerContainer {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 20px;
+}
+
+.logo {
+  width: 73px;
+  height: 10px;
+}
+
+.TabsContainer {
+  display: flex;
+  position: relative;
+  width: 100%;
+  margin-top: 20px;
+}
+
+.TabButton {
+  flex: 1;
+}
+
+.underline {
+  position: absolute;
+  height: 1px;
+  bottom: 0;
+  left: 0;
+  width: 33.33%;
+  background-color: var(--gray-600);
+  transition: all 0.2s ease-in-out;
+}
+
+.layoutContainer {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+.layoutsWrapper {
+  display: flex;
+  width: 300%;
+  height: 100%;
+  transition: all 0.2s ease-in-out;
+}
+
+.tabLayout {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #d6ebfb;
+}
+
+/*스플릿 뷰 */
+@media all and (min-width: 469px) {
+  .headerContainer {
+    position: relative;
+    justify-content: center;
+    align-items: center;
+    flex-direction: row;
+    padding: 20px 0;
+  }
+
+  .logo {
+    position: absolute;
+    left: 20px;
+    width: 122px;
+    height: 17px;
+  }
+
+  .TabsContainer {
+    justify-content: space-between;
+    width: 100%;
+    max-width: 360px;
+    margin-top: 0;
+    margin-left: 120px;
+  }
+
+  .underline {
+    display: none;
+  }
+}
+
+/*웹 뷰 */
+@media all and (min-width: 961px) {
+  .headerContainer {
+    flex-direction: row;
+    padding: 35px 40px;
+  }
+
+  .logo {
+    position: absolute;
+    left: 40px;
+    width: 184px;
+    height: 25px;
+  }
+  .TabsContainer {
+    width: 100%;
+    max-width: 570px;
+    margin-top: 0;
+  }
+
+  .underline {
+    display: none;
+  }
+}

--- a/front-end/src/pages/student/course/StudentCourse.module.css
+++ b/front-end/src/pages/student/course/StudentCourse.module.css
@@ -1,4 +1,4 @@
-.couseLayout {
+.courseLayout {
   width: 100%;
   height: 100vh;
 }

--- a/front-end/src/pages/student/course/StudentCourse.module.css
+++ b/front-end/src/pages/student/course/StudentCourse.module.css
@@ -57,7 +57,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: #d6ebfb;
+  background-color: var(--gray-200);
 }
 
 /*스플릿 뷰 */

--- a/front-end/src/pages/student/course/StudentCourse.tsx
+++ b/front-end/src/pages/student/course/StudentCourse.tsx
@@ -36,7 +36,7 @@ const StudentCourse = () => {
   }, [selectedTab]);
 
   return (
-    <div className={S.couseLayout}>
+    <div className={S.courseLayout}>
       <header className={S.headerContainer}>
         <Logo className={S.logo} />
         <div className={S.TabsContainer}>

--- a/front-end/src/pages/student/course/StudentCourse.tsx
+++ b/front-end/src/pages/student/course/StudentCourse.tsx
@@ -1,0 +1,77 @@
+import S from './StudentCourse.module.css';
+import Logo from '../../../assets/icons/logo.svg?react';
+import LayoutTab from './components/LayoutTab';
+import { useEffect, useRef, useState } from 'react';
+
+const TAB_OPTIONS = [
+  { key: 'request', label: '요청하기' },
+  { key: 'react', label: '반응하기' },
+  { key: 'question', label: '질문하기' },
+];
+
+const StudentCourse = () => {
+  const [selectedTab, setSelectedTab] = useState(TAB_OPTIONS[0].key);
+  const [underlineStyle, setUnderlineStyle] = useState({ left: 0, width: 0 });
+
+  const tabRefs = useRef<{ [key: string]: HTMLButtonElement | null }>({});
+
+  const selectedIndex = TAB_OPTIONS.findIndex((tab) => tab.key === selectedTab);
+
+  const updateUnderline = () => {
+    const activeTab = tabRefs.current[selectedTab];
+    if (activeTab) {
+      setUnderlineStyle({
+        left: activeTab.offsetLeft,
+        width: activeTab.offsetWidth,
+      });
+    }
+  };
+
+  useEffect(() => {
+    updateUnderline();
+    window.addEventListener('resize', updateUnderline);
+    return () => {
+      window.removeEventListener('resize', updateUnderline);
+    };
+  }, [selectedTab]);
+
+  return (
+    <div className={S.couseLayout}>
+      <header className={S.headerContainer}>
+        <Logo className={S.logo} />
+        <div className={S.TabsContainer}>
+          {TAB_OPTIONS.map(({ key, label }) => (
+            <button
+              key={key}
+              ref={(el) => (tabRefs.current[key] = el)}
+              className={S.TabButton}
+              onClick={() => {
+                setSelectedTab(key);
+              }}
+            >
+              <LayoutTab text={label} isActive={selectedTab === key} />
+            </button>
+          ))}
+          <div
+            className={S.underline}
+            style={{ left: underlineStyle.left, width: underlineStyle.width }}
+          ></div>
+        </div>
+      </header>
+      <div className={S.layoutContainer}>
+        <div
+          className={S.layoutsWrapper}
+          style={{
+            transform: `translateX(-${selectedIndex * 33.33}%)`,
+          }}
+        >
+          <div className={S.tabLayout}>요청하기 화면</div>
+          <div className={S.tabLayout}>반응하기 화면</div>
+          <div className={S.tabLayout}>질문하기 화면</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StudentCourse;

--- a/front-end/src/pages/student/course/components/LayoutTab.module.css
+++ b/front-end/src/pages/student/course/components/LayoutTab.module.css
@@ -14,3 +14,17 @@
 .active {
   color: var(--gray-600);
 }
+
+/*스플릿 뷰 */
+@media all and (min-width: 469px) {
+  .TabContainer {
+    font: var(--web-button4-bold);
+  }
+}
+
+/*웹 뷰 */
+@media all and (min-width: 961px) {
+  .TabContainer {
+    font: var(--web-button4-bold);
+  }
+}

--- a/front-end/src/pages/student/course/components/LayoutTab.module.css
+++ b/front-end/src/pages/student/course/components/LayoutTab.module.css
@@ -1,0 +1,16 @@
+.TabContainer {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font: var(--mobile-button1-bold);
+  color: var(--gray-400);
+  flex: 1;
+  text-align: center;
+  padding: 16px;
+  cursor: pointer;
+}
+
+.active {
+  color: var(--gray-600);
+}

--- a/front-end/src/pages/student/course/components/LayoutTab.tsx
+++ b/front-end/src/pages/student/course/components/LayoutTab.tsx
@@ -1,0 +1,16 @@
+import S from './LayoutTab.module.css';
+
+type LayoutTabProps = {
+  text: string;
+  isActive: boolean;
+};
+
+const LayoutTab = ({ text, isActive }: LayoutTabProps) => {
+  return (
+    <div className={`${S.TabContainer} ${isActive ? S.active : ''}`}>
+      {text}
+    </div>
+  );
+};
+
+export default LayoutTab;

--- a/front-end/src/pages/student/course/index.tsx
+++ b/front-end/src/pages/student/course/index.tsx
@@ -1,9 +1,0 @@
-const StudentCourse = () => {
-  return (
-    <div>
-      <h1>Student Course</h1>
-    </div>
-  );
-};
-
-export default StudentCourse;


### PR DESCRIPTION


## #️⃣ 연관된 이슈
- #50 

## 📝 작업 내용

- 학생 강의 페이지 레이아웃 구현 
  -  layout tab 구현 

https://github.com/user-attachments/assets/eb92d315-1db9-4034-8da5-61a93b81e975


## 💬 리뷰 요구사항(선택)
- 디자인 자체가 스플릿이나 웹이 가장 큰거에 중점이 되어있어서 제대로  헤더가 생기지 않아서 임의로 겹치지않게 디자인을 구현했습니다.
- 모바일사이즈일때 탭에서 선택되었을때 underLine이 생기는데 의도적으로 화면의 크기를 줄이거나 키웠을때 같이 크기가 따라가도록 구현했습니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Launched an enhanced Student Course page featuring a dynamic tabbed interface, enabling smooth navigation between interactive sections.
	- Added an interactive tab component for effortless switching between different course views.

- **Style**
	- Improved visual layout with responsive design and fluid transitions to ensure an optimal experience across devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->