### PR TITLE
[FE] 학생 요청하기 페이지 구현 

### DIFF
--- a/front-end/src/hooks/useBlockTimer.ts
+++ b/front-end/src/hooks/useBlockTimer.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState, useRef } from 'react';
+
+const useBlockTimer = (
+  isSelected: boolean,
+  setIsSelected: React.Dispatch<React.SetStateAction<boolean>>,
+  blockDuration: number,
+  delay: number
+) => {
+  const [isBlocked, setIsBlocked] = useState(false);
+  const [countdown, setCountdown] = useState(blockDuration / 1000); // 초기값 설정
+
+  const blockTimerRef = useRef<number | null>(null);
+  const countdownIntervalRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isSelected) {
+      setIsBlocked(false);
+      setCountdown(blockDuration / 1000); // 초기값으로 리셋
+      return;
+    }
+
+    setTimeout(() => {
+      setIsBlocked(true);
+      setCountdown(blockDuration / 1000);
+
+      //시간 줄이는 기능
+      countdownIntervalRef.current = setInterval(() => {
+        setCountdown((prev) => (prev > 1 ? prev - 1 : 0));
+      }, 1000);
+
+      //끝나고 초기화
+      blockTimerRef.current = setTimeout(() => {
+        setIsSelected(false);
+        setIsBlocked(false);
+        setCountdown(blockDuration / 1000);
+      }, blockDuration);
+    }, delay);
+
+    return () => {
+      clearTimeout(blockTimerRef.current!);
+      clearInterval(countdownIntervalRef.current!);
+    };
+  }, [isSelected, blockDuration, delay]);
+
+  return { isBlocked, countdown };
+};
+
+export default useBlockTimer;

--- a/front-end/src/pages/student/course/StudentCourse.module.css
+++ b/front-end/src/pages/student/course/StudentCourse.module.css
@@ -1,6 +1,8 @@
 .courseLayout {
   width: 100%;
   height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .headerContainer {
@@ -39,7 +41,7 @@
 
 .layoutContainer {
   width: 100%;
-  height: 100%;
+  flex: 1;
   overflow: hidden;
   position: relative;
 }
@@ -54,9 +56,6 @@
 .tabLayout {
   width: 100%;
   height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
   background-color: var(--gray-200);
 }
 
@@ -82,7 +81,6 @@
     width: 100%;
     max-width: 360px;
     margin-top: 0;
-    margin-left: 120px;
   }
 
   .underline {

--- a/front-end/src/pages/student/course/StudentCourse.tsx
+++ b/front-end/src/pages/student/course/StudentCourse.tsx
@@ -2,6 +2,8 @@ import S from './StudentCourse.module.css';
 import Logo from '../../../assets/icons/logo.svg?react';
 import LayoutTab from './components/LayoutTab';
 import { useEffect, useRef, useState } from 'react';
+import StudentRequest from './request/StudentRequest';
+import { useParams } from 'react-router';
 
 const TAB_OPTIONS = [
   { key: 'request', label: '요청하기' },
@@ -10,6 +12,7 @@ const TAB_OPTIONS = [
 ];
 
 const StudentCourse = () => {
+  const { courseId } = useParams();
   const [selectedTab, setSelectedTab] = useState(TAB_OPTIONS[0].key);
   const [underlineStyle, setUnderlineStyle] = useState({ left: 0, width: 0 });
 
@@ -65,7 +68,9 @@ const StudentCourse = () => {
             transform: `translateX(-${selectedIndex * 33.33}%)`,
           }}
         >
-          <div className={S.tabLayout}>요청하기 화면</div>
+          <div className={S.tabLayout}>
+            <StudentRequest courseId={courseId ?? ''} />
+          </div>
           <div className={S.tabLayout}>반응하기 화면</div>
           <div className={S.tabLayout}>질문하기 화면</div>
         </div>

--- a/front-end/src/pages/student/course/components/LayoutTab.module.css
+++ b/front-end/src/pages/student/course/components/LayoutTab.module.css
@@ -25,6 +25,6 @@
 /*웹 뷰 */
 @media all and (min-width: 961px) {
   .TabContainer {
-    font: var(--web-button4-bold);
+    font: var(--web-button2-bold);
   }
 }

--- a/front-end/src/pages/student/course/components/SuccessPopup.module.css
+++ b/front-end/src/pages/student/course/components/SuccessPopup.module.css
@@ -1,0 +1,31 @@
+.popupContainer {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 0;
+  width: 90%;
+  text-align: center;
+  padding: 12px 0;
+  border-radius: 8px;
+  color: white;
+  font: var(--mobile-button1-medium);
+  background-color: #010515;
+  opacity: 0.8;
+  animation: move 2s ease-in-out;
+}
+
+@keyframes move {
+  0% {
+    bottom: 0;
+    opacity: 0;
+  }
+  50% {
+    bottom: 47px;
+    opacity: 1;
+  }
+  100% {
+    bottom: 0;
+    opacity: 0;
+    display: none;
+  }
+}

--- a/front-end/src/pages/student/course/components/SuccessPopup.tsx
+++ b/front-end/src/pages/student/course/components/SuccessPopup.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import S from './SuccessPopup.module.css';
+
+type SuccessPopupProps = {
+  text: string;
+  onClose: () => void;
+};
+
+const SuccessPopup = ({ text, onClose }: SuccessPopupProps) => {
+  useEffect(() => {
+    const timer = setTimeout(onClose, 2000);
+    return () => clearTimeout(timer);
+  }, [onClose]);
+
+  return <div className={S.popupContainer}>{text}</div>;
+};
+
+export default SuccessPopup;

--- a/front-end/src/pages/student/course/request/StudentRequest.module.css
+++ b/front-end/src/pages/student/course/request/StudentRequest.module.css
@@ -1,0 +1,71 @@
+.pageLayout {
+  display: flex;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+  align-items: center;
+  padding: 64px 20px;
+}
+
+.requestTitle {
+  font: var(--mobile-title1-bold);
+  color: var(--gray-900);
+  text-align: center;
+  margin-bottom: 4px;
+}
+
+.titleStrong {
+  color: var(--blue-400);
+}
+
+.requestDesc {
+  font: var(--mobile-body1-medium);
+  color: var(--gray-500);
+  text-align: center;
+  margin-bottom: 36px;
+}
+
+.cardContainer {
+  width: 100%;
+  max-width: 428px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+/*스플릿 뷰 */
+@media all and (min-width: 469px) {
+  .requestTitle {
+    font: var(--web-title3-bold);
+    margin-bottom: 8px;
+  }
+
+  .requestDesc {
+    font: var(--web-body2-medium);
+    margin-bottom: 40px;
+  }
+
+  .cardContainer {
+    gap: 12px;
+  }
+}
+
+/*웹 뷰 */
+@media all and (min-width: 961px) {
+  .requestTitle {
+    font: var(--web-header3-bold);
+    margin-bottom: 12px;
+  }
+
+  .requestDesc {
+    font: var(--web-title3-medium);
+    margin-bottom: 44px;
+  }
+
+  .cardContainer {
+    max-width: 676px;
+    gap: 12px;
+  }
+}

--- a/front-end/src/pages/student/course/request/StudentRequest.tsx
+++ b/front-end/src/pages/student/course/request/StudentRequest.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import RequestCard from './components/RequestCard';
+import S from './StudentRequest.module.css';
+import { classroomRepository } from '../../../../di';
+import SuccessPopup from '../components/SuccessPopup';
+
+const CARD_TYPES = ['hard', 'fast', 'question', 'size', 'sound'] as const;
+export type CardType = 'hard' | 'fast' | 'question' | 'size' | 'sound';
+
+const StudentRequest = ({ courseId }: { courseId: string }) => {
+  const [successPopup, setSuccessPopup] = useState<boolean>(false);
+
+  const handleCardClick = async (type: CardType) => {
+    try {
+      await classroomRepository.sendRequest(courseId, type);
+      setSuccessPopup(true);
+      return true;
+    } catch (error) {
+      console.error(error);
+      return false;
+    }
+  };
+
+  return (
+    <div className={S.pageLayout}>
+      <div className={S.requestTitle}>
+        <span className={S.titleStrong}>불편 사항</span>이 있을 때 사용해보세요{' '}
+      </div>
+      <div className={S.requestDesc}>
+        수업 중 말하기 힘들 때 이모지로 알릴 수 있어요
+      </div>
+      <div className={S.cardContainer}>
+        {CARD_TYPES.map((type) => (
+          <RequestCard
+            key={type}
+            type={type}
+            onCardClick={() => handleCardClick(type)}
+          />
+        ))}
+      </div>
+      {successPopup && (
+        <SuccessPopup
+          text="라이브 피드백 전송 성공"
+          onClose={() => setSuccessPopup(false)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default StudentRequest;

--- a/front-end/src/pages/student/course/request/StudentRequest.tsx
+++ b/front-end/src/pages/student/course/request/StudentRequest.tsx
@@ -3,9 +3,49 @@ import RequestCard from './components/RequestCard';
 import S from './StudentRequest.module.css';
 import { classroomRepository } from '../../../../di';
 import SuccessPopup from '../components/SuccessPopup';
+import WishSvg from '../../../../assets/icons/wish-emoji.svg?react';
+import WindSvg from '../../../../assets/icons/wind-emoji.svg?react';
+import BulbSvg from '../../../../assets/icons/bulb-emoji.svg?react';
+import MagnifierSvg from '../../../../assets/icons/magnifier-emoji.svg?react';
+import EarSvg from '../../../../assets/icons/ear-emoji.svg?react';
+import {
+  RequestFast,
+  RequestHard,
+  RequestQuestion,
+  RequestSize,
+  RequestSound,
+} from '../../../../core/model';
 
 const CARD_TYPES = ['hard', 'fast', 'question', 'size', 'sound'] as const;
 export type CardType = 'hard' | 'fast' | 'question' | 'size' | 'sound';
+
+const CARD_CONTENT = {
+  hard: {
+    icon: <WishSvg className={S.icon} />,
+    title: RequestHard.title,
+    description: RequestHard.description,
+  },
+  fast: {
+    icon: <WindSvg className={S.icon} />,
+    title: RequestFast.title,
+    description: RequestFast.description,
+  },
+  question: {
+    icon: <BulbSvg className={S.icon} />,
+    title: RequestQuestion.title,
+    description: RequestQuestion.description,
+  },
+  size: {
+    icon: <MagnifierSvg className={S.icon} />,
+    title: RequestSize.title,
+    description: RequestSize.description,
+  },
+  sound: {
+    icon: <EarSvg className={S.icon} />,
+    title: RequestSound.title,
+    description: RequestSound.description,
+  },
+};
 
 const StudentRequest = ({ courseId }: { courseId: string }) => {
   const [successPopup, setSuccessPopup] = useState<boolean>(false);
@@ -33,8 +73,10 @@ const StudentRequest = ({ courseId }: { courseId: string }) => {
         {CARD_TYPES.map((type) => (
           <RequestCard
             key={type}
-            type={type}
             onCardClick={() => handleCardClick(type)}
+            title={CARD_CONTENT[type].title}
+            description={CARD_CONTENT[type].description}
+            icon={CARD_CONTENT[type].icon}
           />
         ))}
       </div>

--- a/front-end/src/pages/student/course/request/components/RequestCard.module.css
+++ b/front-end/src/pages/student/course/request/components/RequestCard.module.css
@@ -1,0 +1,144 @@
+.cardContainer {
+  position: relative;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  background-color: white;
+  padding: 12px;
+  border-radius: 12px;
+  transition: all 0.2s ease-in-out;
+}
+
+.cardContainer:hover {
+  border: 1px solid var(--blue-400);
+  transform: scale(1.05);
+}
+
+@keyframes activeAnimation {
+  0% {
+    transform: scale(1);
+    background-color: initial;
+  }
+  100% {
+    transform: scale(1.08);
+    background-color: var(--blue-200);
+  }
+}
+
+.active {
+  animation: activeAnimation 0.4s ease-in-out forwards;
+}
+
+.blocked {
+  pointer-events: none;
+  animation: none;
+}
+
+.iconBg {
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--bg);
+  border-radius: 24px;
+}
+
+.icon {
+  width: 27px;
+  height: 27px;
+}
+
+.cardContentContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  gap: 4px;
+  margin-left: 34px;
+}
+.cardTitle {
+  font: var(--mobile-title2-bold);
+  color: var(--gray-900);
+}
+
+.cardDesc {
+  font: var(--mobile-body2-medium);
+  color: var(--gray-600);
+}
+
+.countdownText {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 12px;
+  border: 4px solid var(--blue-200);
+  font: var(--mobile-title2-bold);
+  color: var(--blue-400);
+  background-color: rgba(230, 234, 255, 0.6);
+  backdrop-filter: blur(10px);
+}
+
+/*스플릿 뷰 */
+@media all and (min-width: 469px) {
+  .cardContainer {
+    padding: 8px 12px;
+  }
+
+  .icon {
+    width: 36px;
+    height: 36px;
+  }
+
+  .iconBg {
+    width: 64px;
+    height: 64px;
+    border-radius: 36px;
+  }
+
+  .cardContentContainer {
+    margin-left: 24px;
+  }
+  .cardTitle {
+    font: var(--web-title5-bold);
+  }
+
+  .cardDesc {
+    font: var(--web-body3-medium);
+  }
+}
+
+/*웹 뷰 */
+@media all and (min-width: 961px) {
+  .cardContainer {
+    padding: 16px 40px;
+    border-radius: 12px;
+  }
+
+  .icon {
+    width: 56px;
+    height: 56px;
+  }
+
+  .iconBg {
+    width: 88px;
+    height: 88px;
+    border-radius: 64px;
+  }
+
+  .cardContentContainer {
+    gap: 8px;
+    margin-left: 40px;
+  }
+  .cardTitle {
+    font: var(--web-title1-bold);
+  }
+
+  .cardDesc {
+    font: var(--web-title4-medium);
+  }
+}

--- a/front-end/src/pages/student/course/request/components/RequestCard.tsx
+++ b/front-end/src/pages/student/course/request/components/RequestCard.tsx
@@ -1,56 +1,21 @@
 import S from './RequestCard.module.css';
-import WishSvg from '../../../../../assets/icons/wish-emoji.svg?react';
-import WindSvg from '../../../../../assets/icons/wind-emoji.svg?react';
-import BulbSvg from '../../../../../assets/icons/bulb-emoji.svg?react';
-import MagnifierSvg from '../../../../../assets/icons/magnifier-emoji.svg?react';
-import EarSvg from '../../../../../assets/icons/ear-emoji.svg?react';
-import {
-  RequestFast,
-  RequestHard,
-  RequestQuestion,
-  RequestSize,
-  RequestSound,
-} from '../../../../../core/model';
-import { CardType } from '../StudentRequest';
 import useBlockTimer from '../../../../../hooks/useBlockTimer';
 import { useState } from 'react';
 
-const CARD_CONTENT = {
-  hard: {
-    icon: <WishSvg className={S.icon} />,
-    title: RequestHard.title,
-    description: RequestHard.description,
-  },
-  fast: {
-    icon: <WindSvg className={S.icon} />,
-    title: RequestFast.title,
-    description: RequestFast.description,
-  },
-  question: {
-    icon: <BulbSvg className={S.icon} />,
-    title: RequestQuestion.title,
-    description: RequestQuestion.description,
-  },
-  size: {
-    icon: <MagnifierSvg className={S.icon} />,
-    title: RequestSize.title,
-    description: RequestSize.description,
-  },
-  sound: {
-    icon: <EarSvg className={S.icon} />,
-    title: RequestSound.title,
-    description: RequestSound.description,
-  },
-};
-
 type RequestCardProps = {
-  type: CardType;
   onCardClick: () => Promise<boolean>;
+  icon: JSX.Element;
+  title: string;
+  description: string;
 };
 
-const RequestCard = ({ type, onCardClick }: RequestCardProps) => {
+const RequestCard = ({
+  onCardClick,
+  icon,
+  title,
+  description,
+}: RequestCardProps) => {
   const [isSelected, setIsSelected] = useState<boolean>(false);
-  const { icon, title, description } = CARD_CONTENT[type] || {};
   const { isBlocked, countdown } = useBlockTimer(
     isSelected,
     setIsSelected,

--- a/front-end/src/pages/student/course/request/components/RequestCard.tsx
+++ b/front-end/src/pages/student/course/request/components/RequestCard.tsx
@@ -1,0 +1,84 @@
+import S from './RequestCard.module.css';
+import WishSvg from '../../../../../assets/icons/wish-emoji.svg?react';
+import WindSvg from '../../../../../assets/icons/wind-emoji.svg?react';
+import BulbSvg from '../../../../../assets/icons/bulb-emoji.svg?react';
+import MagnifierSvg from '../../../../../assets/icons/magnifier-emoji.svg?react';
+import EarSvg from '../../../../../assets/icons/ear-emoji.svg?react';
+import {
+  RequestFast,
+  RequestHard,
+  RequestQuestion,
+  RequestSize,
+  RequestSound,
+} from '../../../../../core/model';
+import { CardType } from '../StudentRequest';
+import useBlockTimer from '../../../../../hooks/useBlockTimer';
+import { useState } from 'react';
+
+const CARD_CONTENT = {
+  hard: {
+    icon: <WishSvg className={S.icon} />,
+    title: RequestHard.title,
+    description: RequestHard.description,
+  },
+  fast: {
+    icon: <WindSvg className={S.icon} />,
+    title: RequestFast.title,
+    description: RequestFast.description,
+  },
+  question: {
+    icon: <BulbSvg className={S.icon} />,
+    title: RequestQuestion.title,
+    description: RequestQuestion.description,
+  },
+  size: {
+    icon: <MagnifierSvg className={S.icon} />,
+    title: RequestSize.title,
+    description: RequestSize.description,
+  },
+  sound: {
+    icon: <EarSvg className={S.icon} />,
+    title: RequestSound.title,
+    description: RequestSound.description,
+  },
+};
+
+type RequestCardProps = {
+  type: CardType;
+  onCardClick: () => Promise<boolean>;
+};
+
+const RequestCard = ({ type, onCardClick }: RequestCardProps) => {
+  const [isSelected, setIsSelected] = useState<boolean>(false);
+  const { icon, title, description } = CARD_CONTENT[type] || {};
+  const { isBlocked, countdown } = useBlockTimer(
+    isSelected,
+    setIsSelected,
+    60000,
+    2000
+  );
+
+  const handleButtonClick = async () => {
+    const success = await onCardClick();
+    if (success) {
+      setIsSelected(true);
+    }
+  };
+
+  return (
+    <button
+      className={`${S.cardContainer} ${isSelected ? S.active : ''} ${isBlocked ? S.blocked : ''} `}
+      onClick={handleButtonClick}
+      disabled={!!isSelected || isBlocked}
+    >
+      <div className={S.iconBg}>{icon}</div>
+      <div className={S.cardContentContainer}>
+        <div className={S.cardTitle}>{title}</div>
+        <div className={S.cardDesc}>{description}</div>
+      </div>
+      {isBlocked && <div className={S.countdownText}>{countdown}</div>}
+    </button>
+  );
+};
+
+export default RequestCard;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #87 

## 📝 작업 내용

- 요청하는 카드 컴포넌트 구현
- 카드 컴포넌트 애니메이션 구현
- 요청 페이지 구현
- 반응형으로 모바일,스플릿, 웹 뷰 구현
- 블록 타이머 커스텀 훅으로 구현 

https://github.com/user-attachments/assets/7c364f1b-fdca-4cbe-901b-1b1aa994b7cb



## 💬 리뷰 요구사항(선택)
- 버튼을 클릭했을때 애니메이션이 진행 되는 상태와  애니메이션이 끝이나면  해당 시간만큼 블록으로 막아야되는 상태가 있는데 
  처음에는  두부분을 하나의 state로 관리하여 처리하려고 했는데 애니메이션과 블록으로 막는 기능은 다른 성질이라고 생각하여 각각의 state를 분리해서 구현했습니다.  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Launched an interactive course request interface allowing users to submit various requests, complete with visual feedback.
  - Introduced an auto-dismissing success popup that confirms successful submissions.
  - Added safeguards that display a countdown to prevent rapid repeated interactions.

- **Style**
  - Enhanced overall responsiveness with improved layouts and typography for a modern, cleaner user experience.
  - Updated component styling to ensure balanced spacing and alignment across different screen sizes.
  - New CSS modules introduced for improved styling of request cards and success popups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->