### PR TITLE
[FE] 학생 반응하기 페이지 구현 

### DIFF
--- a/front-end/src/pages/student/course/StudentCourse.tsx
+++ b/front-end/src/pages/student/course/StudentCourse.tsx
@@ -4,6 +4,7 @@ import LayoutTab from './components/LayoutTab';
 import { useEffect, useRef, useState } from 'react';
 import StudentRequest from './request/StudentRequest';
 import { useParams } from 'react-router';
+import StudentReact from './react/StudentReact';
 
 const TAB_OPTIONS = [
   { key: 'request', label: '요청하기' },
@@ -71,7 +72,9 @@ const StudentCourse = () => {
           <div className={S.tabLayout}>
             <StudentRequest courseId={courseId ?? ''} />
           </div>
-          <div className={S.tabLayout}>반응하기 화면</div>
+          <div className={S.tabLayout}>
+            <StudentReact courseId={courseId ?? ''} />
+          </div>
           <div className={S.tabLayout}>질문하기 화면</div>
         </div>
       </div>

--- a/front-end/src/pages/student/course/components/SuccessPopup.module.css
+++ b/front-end/src/pages/student/course/components/SuccessPopup.module.css
@@ -1,9 +1,13 @@
 .popupContainer {
   position: absolute;
   left: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transform: translateX(-50%);
   bottom: 0;
   width: 90%;
+  max-width: 427px;
   text-align: center;
   padding: 12px 0;
   border-radius: 8px;
@@ -27,5 +31,21 @@
     bottom: 0;
     opacity: 0;
     display: none;
+  }
+}
+
+/*스플릿 뷰 */
+@media all and (min-width: 600px) {
+  .popupContainer {
+    max-width: 427px;
+    height: 52px;
+  }
+}
+
+/*웹 뷰 */
+@media all and (min-width: 961px) {
+  .popupContainer {
+    max-width: 676px;
+    height: 66px;
   }
 }

--- a/front-end/src/pages/student/course/react/StudentReact.module.css
+++ b/front-end/src/pages/student/course/react/StudentReact.module.css
@@ -1,0 +1,71 @@
+.pageLayout {
+  display: flex;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+  align-items: center;
+  padding: 128px 20px;
+}
+
+.reactTitle {
+  font: var(--mobile-title1-bold);
+  color: var(--gray-900);
+  text-align: center;
+  margin-bottom: 4px;
+}
+
+.titleStrong {
+  color: var(--blue-400);
+}
+
+.reactDesc {
+  font: var(--mobile-body1-medium);
+  color: var(--gray-500);
+  text-align: center;
+  margin-bottom: 36px;
+}
+
+.cardContainer {
+  width: 100%;
+  max-width: fit-content;
+  display: grid;
+  place-items: center;
+  grid-template-columns: repeat(3, 1fr); /* 3열 */
+  grid-template-rows: repeat(2, 1fr); /* 2행 */
+  gap: 16px;
+}
+
+/*스플릿 뷰 */
+@media all and (min-width: 600px) {
+  .reactTitle {
+    font: var(--web-title3-bold);
+    margin-bottom: 8px;
+  }
+
+  .reactDesc {
+    font: var(--web-body2-medium);
+    margin-bottom: 80px;
+  }
+
+  .cardContainer {
+    gap: 24px;
+  }
+}
+
+/*웹 뷰 */
+@media all and (min-width: 961px) {
+  .reactTitle {
+    font: var(--web-header3-bold);
+    margin-bottom: 12px;
+  }
+
+  .reactDesc {
+    font: var(--web-title3-medium);
+    margin-bottom: 64px;
+  }
+
+  .cardContainer {
+    gap: 24px;
+  }
+}

--- a/front-end/src/pages/student/course/react/StudentReact.tsx
+++ b/front-end/src/pages/student/course/react/StudentReact.tsx
@@ -1,0 +1,61 @@
+import S from './StudentReact.module.css';
+import OkaySvg from '../../../../assets/icons/okay-emoji.svg?react';
+import ClapSvg from '../../../../assets/icons/clap-emoji.svg?react';
+import ThumbUpSvg from '../../../../assets/icons/thumb-up-emoji.svg?react';
+import HeartSvg from '../../../../assets/icons/heart-emoji.svg?react';
+import CrySvg from '../../../../assets/icons/cry-emoji.svg?react';
+import ScreamSvg from '../../../../assets/icons/scream-emoji.svg?react';
+import SuccessPopup from '../components/SuccessPopup';
+import { useState } from 'react';
+import ReactCard from './components/ReactCard';
+import { classroomRepository } from '../../../../di';
+import { Reaction } from '../../../../core/model';
+
+const CARD_List = [
+  { type: 'okay', icon: OkaySvg },
+  { type: 'clap', icon: ClapSvg },
+  { type: 'thumb', icon: ThumbUpSvg },
+  { type: 'scream', icon: ScreamSvg },
+  { type: 'cry', icon: CrySvg },
+  { type: 'like', icon: HeartSvg },
+] as const;
+
+const StudentReact = ({ courseId }: { courseId: string }) => {
+  const [successPopup, setSuccessPopup] = useState<boolean>(false);
+
+  const handleCardClick = async (reaction: Reaction) => {
+    try {
+      await classroomRepository.sendReaction(courseId, reaction);
+      setSuccessPopup(true);
+      return true;
+    } catch (error) {
+      console.error(error);
+      return false;
+    }
+  };
+  return (
+    <div className={S.pageLayout}>
+      <div className={S.reactTitle}>
+        <span className={S.titleStrong}>간단한 반응</span>을 남기며 소통해보세요
+      </div>
+      <div className={S.reactDesc}>이모지로 가볍게 감정을 표현할 수 있어요</div>
+      <div className={S.cardContainer}>
+        {CARD_List.map((item) => (
+          <ReactCard
+            key={item.type}
+            Icon={item.icon}
+            onCardClick={() => handleCardClick(item.type)}
+          />
+        ))}
+      </div>
+      {successPopup && (
+        <SuccessPopup
+          text="라이브 피드백 전송 성공"
+          onClose={() => setSuccessPopup(false)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default StudentReact;

--- a/front-end/src/pages/student/course/react/StudentReact.tsx
+++ b/front-end/src/pages/student/course/react/StudentReact.tsx
@@ -50,7 +50,7 @@ const StudentReact = ({ courseId }: { courseId: string }) => {
       </div>
       {successPopup && (
         <SuccessPopup
-          text="라이브 피드백 전송 성공"
+          text="라이브 이모지 전송 성공"
           onClose={() => setSuccessPopup(false)}
         />
       )}

--- a/front-end/src/pages/student/course/react/components/ReactCard.module.css
+++ b/front-end/src/pages/student/course/react/components/ReactCard.module.css
@@ -1,0 +1,94 @@
+.cardContainer {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 96px;
+  height: 96px;
+  padding: 21px;
+  border-radius: 48px;
+  border: 2px solid white;
+  background-color: rgba(255, 255, 255, 0.5);
+}
+
+.cardContainer:hover {
+  border: 1px solid var(--blue-400);
+  transform: scale(1.2);
+  rotate: 10deg;
+}
+
+@keyframes activeAnimation {
+  0% {
+    transform: scale(1);
+    background-color: initial;
+  }
+  50% {
+    transform: scale(1.07);
+    border: 1px solid var(--blue-400);
+    background-color: var(--blue-200);
+  }
+  100% {
+    transform: scale(1);
+    border: 1px solid var(--blue-400);
+    background-color: var(--blue-200);
+  }
+}
+
+.active {
+  animation: activeAnimation 0.4s ease-in-out forwards;
+}
+
+.blocked {
+  pointer-events: none;
+  animation: none;
+}
+
+.icon {
+  width: 100%;
+  height: 100%;
+}
+
+.countdownText {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 72px;
+  border: 6px solid var(--blue-200);
+  font: var(--mobile-title2-bold);
+  color: var(--blue-400);
+  background-color: rgba(230, 234, 255, 0.6);
+  backdrop-filter: blur(10px);
+}
+
+/*스플릿 뷰 */
+@media all and (min-width: 600px) {
+  .cardContainer {
+    width: 144px;
+    height: 144px;
+    padding: 31px;
+    border-radius: 108px;
+  }
+  .countdownText {
+    border-radius: 108px;
+    font: var(--web-title1-bold);
+  }
+}
+
+/*웹 뷰 */
+@media all and (min-width: 961px) {
+  .cardContainer {
+    width: 144px;
+    height: 144px;
+    padding: 31px;
+    border-radius: 72px;
+  }
+  .countdownText {
+    border-radius: 108px;
+    font: var(--web-title1-bold);
+  }
+}

--- a/front-end/src/pages/student/course/react/components/ReactCard.tsx
+++ b/front-end/src/pages/student/course/react/components/ReactCard.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import S from './ReactCard.module.css';
+import useBlockTimer from '../../../../../hooks/useBlockTimer';
+
+type ReactCardProps = {
+  Icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  onCardClick: () => Promise<boolean>;
+};
+
+const ReactCard = ({ Icon, onCardClick }: ReactCardProps) => {
+  const [isSelected, setIsSelected] = useState<boolean>(false);
+  const { isBlocked, countdown } = useBlockTimer(
+    isSelected,
+    setIsSelected,
+    10000,
+    2000
+  );
+
+  const handleButtonClick = async () => {
+    const success = await onCardClick();
+    if (success) {
+      setIsSelected(true);
+    }
+  };
+
+  return (
+    <button
+      className={`${S.cardContainer} ${isSelected ? S.active : ''} ${isBlocked ? S.blocked : ''} `}
+      disabled={!!isSelected || isBlocked}
+      onClick={handleButtonClick}
+    >
+      <Icon className={S.icon}></Icon>
+      {isBlocked && <div className={S.countdownText}>{countdown}</div>}
+    </button>
+  );
+};
+
+export default ReactCard;

--- a/front-end/src/pages/student/course/request/StudentRequest.tsx
+++ b/front-end/src/pages/student/course/request/StudentRequest.tsx
@@ -16,36 +16,40 @@ import {
   RequestSound,
 } from '../../../../core/model';
 
-const CARD_TYPES = ['hard', 'fast', 'question', 'size', 'sound'] as const;
 export type CardType = 'hard' | 'fast' | 'question' | 'size' | 'sound';
 
-const CARD_CONTENT = {
-  hard: {
-    icon: <WishSvg className={S.icon} />,
+const CARD_CONTENT = [
+  {
+    type: 'hard',
+    icon: WishSvg,
     title: RequestHard.title,
     description: RequestHard.description,
   },
-  fast: {
-    icon: <WindSvg className={S.icon} />,
+  {
+    type: 'fast',
+    icon: WindSvg,
     title: RequestFast.title,
     description: RequestFast.description,
   },
-  question: {
-    icon: <BulbSvg className={S.icon} />,
+  {
+    type: 'question',
+    icon: BulbSvg,
     title: RequestQuestion.title,
     description: RequestQuestion.description,
   },
-  size: {
-    icon: <MagnifierSvg className={S.icon} />,
+  {
+    type: 'size',
+    icon: MagnifierSvg,
     title: RequestSize.title,
     description: RequestSize.description,
   },
-  sound: {
-    icon: <EarSvg className={S.icon} />,
+  {
+    type: 'sound',
+    icon: EarSvg,
     title: RequestSound.title,
     description: RequestSound.description,
   },
-};
+] as const;
 
 const StudentRequest = ({ courseId }: { courseId: string }) => {
   const [successPopup, setSuccessPopup] = useState<boolean>(false);
@@ -70,13 +74,13 @@ const StudentRequest = ({ courseId }: { courseId: string }) => {
         수업 중 말하기 힘들 때 이모지로 알릴 수 있어요
       </div>
       <div className={S.cardContainer}>
-        {CARD_TYPES.map((type) => (
+        {CARD_CONTENT.map((item) => (
           <RequestCard
-            key={type}
-            onCardClick={() => handleCardClick(type)}
-            title={CARD_CONTENT[type].title}
-            description={CARD_CONTENT[type].description}
-            icon={CARD_CONTENT[type].icon}
+            key={item.type}
+            onCardClick={() => handleCardClick(item.type)}
+            title={item.title}
+            description={item.description}
+            Icon={item.icon}
           />
         ))}
       </div>

--- a/front-end/src/pages/student/course/request/components/RequestCard.tsx
+++ b/front-end/src/pages/student/course/request/components/RequestCard.tsx
@@ -4,14 +4,14 @@ import { useState } from 'react';
 
 type RequestCardProps = {
   onCardClick: () => Promise<boolean>;
-  icon: JSX.Element;
+  Icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
   title: string;
   description: string;
 };
 
 const RequestCard = ({
   onCardClick,
-  icon,
+  Icon,
   title,
   description,
 }: RequestCardProps) => {
@@ -36,7 +36,9 @@ const RequestCard = ({
       onClick={handleButtonClick}
       disabled={!!isSelected || isBlocked}
     >
-      <div className={S.iconBg}>{icon}</div>
+      <div className={S.iconBg}>
+        <Icon className={S.icon} />
+      </div>
       <div className={S.cardContentContainer}>
         <div className={S.cardTitle}>{title}</div>
         <div className={S.cardDesc}>{description}</div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #88 

## 📝 작업 내용

- 반응하기 카드 컴포넌트 구현
- 카드 컴포넌트 애니메이션 구현
- 반응 페이지 구현
- 반응형으로 모바일,스플릿, 웹 뷰 구현

https://github.com/user-attachments/assets/eea92b9d-2b02-48c0-b91b-253f760f0c21


## 💬 리뷰 요구사항(선택)
이전 요청하기 페이지에서  cardContent와 type을 나눠서 구현했는데 그럴 필요가 없다는것을 느껴서 하나로 합쳐서 리스트로 구현했습니다. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The course page’s "반응하기" tab now features an interactive reaction experience. Users can select from animated reaction cards to submit feedback and see immediate confirmation.

- **Style**
  - Enhanced visual design with responsive layouts, animated effects, and refined styling for popups and cards, ensuring a consistent and engaging experience across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->