### PR TITLE
[FE] 교수 프로필 페이지 구현

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -6,7 +6,7 @@ import ProfessorHome from './pages/professor/home/ProfessorHome';
 import ProfessorSearch from './pages/professor/home/search';
 import ProfessorLogin from './pages/professor/login/ProfessorLogin';
 import ProfessorRegister from './pages/professor/register/ProfessorRegister';
-import ProfessorProfile from './pages/professor/profile';
+import ProfessorProfile from './pages/professor/home/profile/ProfessorProfile';
 import ProfessorCourse from './pages/professor/course';
 import ProfessorClassRoom from './pages/professor/course/classroom';
 import StudentHome from './pages/student/home/StudentHome';
@@ -22,10 +22,10 @@ function App() {
           <Route element={<ProfessorHomeLayout />}>
             <Route index element={<ProfessorHome />} />
             <Route path="search" element={<ProfessorSearch />} />
+            <Route path="profile" element={<ProfessorProfile />} />
           </Route>
           <Route path="login" element={<ProfessorLogin />} />
           <Route path="register" element={<ProfessorRegister />} />
-          <Route path="profile" element={<ProfessorProfile />} />
           <Route path="course/:courseId">
             <Route index element={<ProfessorCourse />} />
             <Route path="classroom" element={<ProfessorClassRoom />} />

--- a/front-end/src/components/button/text/TextButton.module.css
+++ b/front-end/src/components/button/text/TextButton.module.css
@@ -58,6 +58,12 @@
   border: 1px solid var(--blue-400);
 }
 
+.grayButton {
+  background-color: white;
+  color: var(--gray-700);
+  border: 1px solid var(--gray-500);
+}
+
 .blackButton {
   background-color: var(--gray-900);
   color: white;

--- a/front-end/src/components/button/text/TextButton.tsx
+++ b/front-end/src/components/button/text/TextButton.tsx
@@ -3,7 +3,7 @@ import S from './TextButton.module.css';
 
 type TextButtonProps = {
   type?: 'button' | 'submit';
-  color: 'blue' | 'red' | 'green' | 'black' | 'white' | 'inherit';
+  color: 'blue' | 'red' | 'green' | 'black' | 'gray' | 'white' | 'inherit';
   size: 'web1' | 'web2' | 'web3' | 'web4' | 'mobile1' | 'mobile2';
   width?: string;
   height?: string;
@@ -22,6 +22,8 @@ function getColorClass(color: string): keyof typeof S {
       return S.greenButton;
     case 'black':
       return S.blackButton;
+    case 'gray':
+      return S.grayButton;
     case 'white':
       return S.whiteButton;
     case 'inherit':

--- a/front-end/src/pages/professor/home/profile/ProfessorProfile.module.css
+++ b/front-end/src/pages/professor/home/profile/ProfessorProfile.module.css
@@ -1,0 +1,120 @@
+.background {
+  background-color: var(--bg);
+}
+
+.container {
+  width: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 92px;
+  justify-content: center;
+  margin: 65px 274px;
+  padding-bottom: 131px;
+}
+
+.contentContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.title {
+  font: var(--web-header3-bold);
+  color: var(--gray-900);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  border-radius: var(--medium);
+  outline: 2px solid var(--gray-200);
+}
+
+.profileContent {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 21px;
+  padding: 30px 40px;
+  padding-left: 60px;
+  border-bottom: 2px solid var(--gray-200);
+}
+
+.profileContent:last-child {
+  border-bottom: none;
+}
+
+.subTitle {
+  font: var(--web-title5-bold);
+  color: var(--gray-900);
+}
+
+.profileWrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.profileImageContainer {
+  display: flex;
+  align-items: center;
+  gap: 37px;
+}
+
+.profileImage {
+  width: 115px;
+  height: 115px;
+  border-radius: 50%;
+  background-color: var(--gray-200);
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.profileImage > img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profileImage > svg {
+  width: 65px;
+  height: 65px;
+}
+
+.profileInput {
+  display: none;
+}
+
+.profileButtonContainer {
+  display: flex;
+  gap: 12px;
+}
+
+.text {
+  width: 464px;
+  height: 53px;
+  padding: 16px 20px;
+  border-radius: var(--small);
+  outline: 1.5px solid var(--gray-200);
+  background-color: var(--bg);
+  font: var(--web-body2-medium);
+  color: var(--gray-700);
+}
+
+input.text:focus {
+  outline: 1.5px solid var(--blue-400);
+}
+
+.accountContentText {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.subDescription {
+  font: var(--web-body2-medium);
+  color: var(--gray-500);
+}

--- a/front-end/src/pages/professor/home/profile/ProfessorProfile.tsx
+++ b/front-end/src/pages/professor/home/profile/ProfessorProfile.tsx
@@ -1,0 +1,294 @@
+import { useEffect, useRef, useState } from 'react';
+import S from './ProfessorProfile.module.css';
+import { authRepository, professorRepository } from '../../../../di';
+import BasicProfile from '../../../../assets/icons/basic-profile.svg?react';
+import TextButton from '../../../../components/button/text/TextButton';
+import { validateImage } from '../../../../utils/util';
+import useModal from '../../../../hooks/useModal';
+import AlertModal from '../../../../components/modal/AlertModal';
+
+const createEditButton = ({
+  onEdit,
+  onCancel,
+}: {
+  onEdit: () => void;
+  onCancel: () => void;
+}) => {
+  return (
+    <>
+      <TextButton
+        color="white"
+        size="web3"
+        width="91px"
+        height="53px"
+        text="확인"
+        onClick={onEdit}
+      />
+      <TextButton
+        color="gray"
+        size="web3"
+        width="91px"
+        height="53px"
+        text="취소"
+        onClick={onCancel}
+      />
+    </>
+  );
+};
+
+const ProfessorProfile = () => {
+  const [profile, setProfile] = useState<{
+    profileImage: string;
+    name: string;
+  }>({
+    profileImage: '',
+    name: '',
+  });
+  const [isEdit, setIsEdit] = useState({
+    profile: false,
+    name: false,
+  });
+  const [modal, setModal] = useState<React.ReactNode | null>(null);
+
+  const userEmail = useRef('');
+  const profileInputRef = useRef<HTMLInputElement>(null);
+  const { openModal, closeModal, Modal } = useModal();
+
+  useEffect(() => {
+    professorRepository.getProfessor().then((response) => {
+      setProfile({
+        profileImage: response.profileURL,
+        name: response.name,
+      });
+
+      userEmail.current = response.email;
+    });
+  }, []);
+
+  const handleClickEdit = (type: 'profile' | 'name') => {
+    try {
+      if (type === 'profile') {
+        if (!profile.profileImage) {
+          alert('프로필 사진을 선택해 주세요.');
+          return;
+        }
+        fetch(profile.profileImage)
+          .then((response) => response.blob())
+          .then((blob) => new File([blob], 'profile.jpg', { type: blob.type }))
+          .then((file) => {
+            professorRepository.updateProfessorProfile(file);
+            setIsEdit({ ...isEdit, profile: false });
+          });
+      } else if (type === 'name') {
+        professorRepository.updateProfessorName(profile.name);
+        setIsEdit({ ...isEdit, name: false });
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleClickCancel = (type: 'profile' | 'name') => {
+    if (type === 'profile') {
+      setIsEdit({ ...isEdit, profile: false });
+    } else if (type === 'name') {
+      setIsEdit({ ...isEdit, name: false });
+    }
+  };
+
+  const handleUpdateProfileImage = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const files = event.target.files;
+    if (files) {
+      if (validateImage(files[0])) {
+        setProfile({ ...profile, profileImage: URL.createObjectURL(files[0]) });
+      }
+    }
+  };
+
+  const handleClickLogoutButton = () => {
+    setModal(
+      <AlertModal
+        type="ask"
+        message="정말 로그아웃하시겠습니까?"
+        description="언제든지 다시 로그인 할 수 있습니다. 로그아웃 하시겠습니까?"
+        buttonText="로그아웃 하기"
+        onClickModalButton={() => {
+          authRepository.logout();
+          setModal(null);
+          closeModal();
+        }}
+        onClickCloseButton={closeModal}
+      />
+    );
+    openModal();
+  };
+
+  const handleClickDeleteAccountButton = () => {
+    setModal(
+      <AlertModal
+        type="caution"
+        message="정말 탈퇴하시겠습니까?"
+        description="모든 데이터가 삭제되며 취소할 수 없습니다. 정말 탈퇴하시겠습니까?"
+        buttonText="회원탈퇴하기"
+        onClickModalButton={() => {
+          professorRepository.deleteProfessor();
+          setModal(null);
+          closeModal();
+        }}
+        onClickCloseButton={closeModal}
+      />
+    );
+    openModal();
+  };
+
+  return (
+    <>
+      <div className={S.background}>
+        <div className={S.container}>
+          <div className={S.contentContainer}>
+            <h2 className={S.title}>계정 정보</h2>
+            <div className={S.content}>
+              <div className={S.profileContent}>
+                <h3 className={S.subTitle}>프로필 사진</h3>
+                <div className={S.profileWrapper}>
+                  <div className={S.profileImageContainer}>
+                    <div className={S.profileImage}>
+                      {profile.profileImage ? (
+                        <img src={profile.profileImage} alt="profile" />
+                      ) : (
+                        <BasicProfile />
+                      )}
+                    </div>
+                    {isEdit.profile && (
+                      <>
+                        <input
+                          className={S.profileInput}
+                          type="file"
+                          accept="image/*"
+                          ref={profileInputRef}
+                          onChange={(event) => handleUpdateProfileImage(event)}
+                        />
+                        <TextButton
+                          color="white"
+                          size="web3"
+                          width="182px"
+                          height="53px"
+                          text="다시 고르기"
+                          onClick={(event: React.MouseEvent) => {
+                            event.preventDefault();
+                            profileInputRef.current?.click();
+                          }}
+                        />
+                      </>
+                    )}
+                  </div>
+                  <div className={S.profileButtonContainer}>
+                    {isEdit.profile ? (
+                      createEditButton({
+                        onEdit: () => handleClickEdit('profile'),
+                        onCancel: () => handleClickCancel('profile'),
+                      })
+                    ) : (
+                      <TextButton
+                        color="white"
+                        size="web3"
+                        width="91px"
+                        height="53px"
+                        text="수정"
+                        onClick={() => setIsEdit({ ...isEdit, profile: true })}
+                      />
+                    )}
+                  </div>
+                </div>
+              </div>
+              <div className={S.profileContent}>
+                <h3 className={S.subTitle}>사용자 이름</h3>
+                <div className={S.profileWrapper}>
+                  {isEdit.name ? (
+                    <input
+                      className={S.text}
+                      type="text"
+                      value={profile.name}
+                      onChange={(event) =>
+                        setProfile({ ...profile, name: event.target.value })
+                      }
+                    />
+                  ) : (
+                    <span className={S.text}>{profile.name}</span>
+                  )}
+                  <div className={S.profileButtonContainer}>
+                    {isEdit.name ? (
+                      createEditButton({
+                        onEdit: () => handleClickEdit('name'),
+                        onCancel: () => handleClickCancel('name'),
+                      })
+                    ) : (
+                      <TextButton
+                        color="white"
+                        size="web3"
+                        width="91px"
+                        height="53px"
+                        text="수정"
+                        onClick={() => setIsEdit({ ...isEdit, name: true })}
+                      />
+                    )}
+                  </div>
+                </div>
+              </div>
+              <div className={S.profileContent}>
+                <h3 className={S.subTitle}>이메일 주소</h3>
+                <span className={S.text}>{userEmail.current}</span>
+              </div>
+            </div>
+          </div>
+          <div className={S.contentContainer}>
+            <h2 className={S.title}>계정 관리</h2>
+            <div className={S.content}>
+              <div className={S.profileContent}>
+                <div className={S.profileWrapper}>
+                  <div className={S.accountContentText}>
+                    <h3 className={S.subTitle}>로그아웃</h3>
+                    <span className={S.subDescription}>
+                      언제든지 다시 이메일로 로그인 할 수 있습니다
+                    </span>
+                  </div>
+                  <TextButton
+                    color="white"
+                    size="web3"
+                    width="185px"
+                    height="53px"
+                    text="로그아웃"
+                    onClick={handleClickLogoutButton}
+                  />
+                </div>
+              </div>
+              <div className={S.profileContent}>
+                <div className={S.profileWrapper}>
+                  <div className={S.accountContentText}>
+                    <h3 className={S.subTitle}>회원탈퇴</h3>
+                    <span className={S.subDescription}>
+                      탈퇴시 모든 데이터가 삭제되며 취소할 수 없습니다
+                    </span>
+                  </div>
+                  <TextButton
+                    color="red"
+                    size="web3"
+                    width="185px"
+                    height="53px"
+                    text="회원탈퇴"
+                    onClick={handleClickDeleteAccountButton}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      {modal && <Modal>{modal}</Modal>}
+    </>
+  );
+};
+
+export default ProfessorProfile;

--- a/front-end/src/pages/professor/home/profile/ProfessorProfile.tsx
+++ b/front-end/src/pages/professor/home/profile/ProfessorProfile.tsx
@@ -102,10 +102,21 @@ const ProfessorProfile = () => {
     const files = event.target.files;
     if (files) {
       if (validateImage(files[0])) {
+        if (profile.profileImage.startsWith('blob:')) {
+          URL.revokeObjectURL(profile.profileImage);
+        }
         setProfile({ ...profile, profileImage: URL.createObjectURL(files[0]) });
       }
     }
   };
+
+  useEffect(() => {
+    return () => {
+      if (profile.profileImage.startsWith('blob:')) {
+        URL.revokeObjectURL(profile.profileImage);
+      }
+    };
+  }, [profile.profileImage]);
 
   const offModal = () => {
     setModal(null);

--- a/front-end/src/pages/professor/home/profile/ProfessorProfile.tsx
+++ b/front-end/src/pages/professor/home/profile/ProfessorProfile.tsx
@@ -107,6 +107,11 @@ const ProfessorProfile = () => {
     }
   };
 
+  const offModal = () => {
+    setModal(null);
+    closeModal();
+  };
+
   const handleClickLogoutButton = () => {
     setModal(
       <AlertModal
@@ -116,8 +121,7 @@ const ProfessorProfile = () => {
         buttonText="로그아웃 하기"
         onClickModalButton={() => {
           authRepository.logout();
-          setModal(null);
-          closeModal();
+          offModal();
         }}
         onClickCloseButton={closeModal}
       />
@@ -134,8 +138,7 @@ const ProfessorProfile = () => {
         buttonText="회원탈퇴하기"
         onClickModalButton={() => {
           professorRepository.deleteProfessor();
-          setModal(null);
-          closeModal();
+          offModal();
         }}
         onClickCloseButton={closeModal}
       />

--- a/front-end/src/pages/professor/profile/index.tsx
+++ b/front-end/src/pages/professor/profile/index.tsx
@@ -1,9 +1,0 @@
-const ProfessorProfile = () => {
-  return (
-    <div>
-      <h1>Professor Profile</h1>
-    </div>
-  );
-};
-
-export default ProfessorProfile;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #82 

## 📝 작업 내용

- 교수 프로필 페이지 구현

<img width="1176" alt="스크린샷 2025-02-12 오후 5 49 16" src="https://github.com/user-attachments/assets/a1f71382-6568-41e9-ac10-49c48b416788" />

## 💬 리뷰 요구사항(선택)

- 교수 홈 레이아웃에서 프로필 이미지를 누르면 교수 프로필 페이지로 navigate되는 기능은 conflict가 날 수 있어 추가하지 않았습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Launched an enhanced professor profile page that enables intuitive editing of profile images and names, along with confirmation modals for logout and account deletion.
	- Added a new gray button option for text buttons to improve visual consistency.

- **Style**
	- Introduced various new styles for the professor profile page to enhance layout and presentation.

- **Refactor**
	- Updated navigation grouping so that the professor profile is now accessed within a more logical section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->