### PR TITLE
[BE] 수업 저장시 일정 데이터 저장 실패 

### DIFF
--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
@@ -9,7 +9,6 @@ import com.softeer.reacton.domain.schedule.Schedule;
 import com.softeer.reacton.global.entity.BaseEntity;
 import com.softeer.reacton.global.exception.BaseException;
 import com.softeer.reacton.global.exception.code.CourseErrorCode;
-import com.softeer.reacton.global.util.TimeUtil;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +44,7 @@ public class Course extends BaseEntity {
     @Column(nullable = false, length = 20)
     private CourseType type; // 수업 종류 (전공, 교양, 기타)
 
+    @Setter
     @Column(nullable = false, unique = true)
     private int accessCode;
 
@@ -84,19 +84,15 @@ public class Course extends BaseEntity {
         this.professor = professor;
     }
 
-    public static Course create(CourseRequest request, int accessCode, Professor professor) {
-        Course course = Course.builder()
+    public static Course create(CourseRequest request, Professor professor) {
+        return Course.builder()
                 .name(request.getName())
                 .courseCode(request.getCourseCode())
                 .capacity(request.getCapacity())
                 .university(request.getUniversity())
                 .type(request.getType())
-                .accessCode(accessCode)
                 .professor(professor)
                 .build();
-
-        course.schedules = createScheduleList(request, course);
-        return course;
     }
 
     public void update(CourseRequest request) {
@@ -105,20 +101,6 @@ public class Course extends BaseEntity {
         this.capacity = request.getCapacity();
         this.university = request.getUniversity();
         this.type = request.getType();
-
-        this.schedules.clear();
-        this.schedules.addAll(createScheduleList(request, this));
-    }
-
-    private static List<Schedule> createScheduleList(CourseRequest request, Course course) {
-        return request.getSchedules().stream()
-                .map(scheduleRequest -> Schedule.builder()
-                        .day(scheduleRequest.getDay())
-                        .startTime(TimeUtil.parseTime(scheduleRequest.getStartTime()))
-                        .endTime(TimeUtil.parseTime(scheduleRequest.getEndTime()))
-                        .course(course)
-                        .build())
-                .toList();
     }
 
     public void activate() {

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -4,7 +4,9 @@ import com.softeer.reacton.domain.course.dto.*;
 import com.softeer.reacton.domain.professor.Professor;
 import com.softeer.reacton.domain.professor.ProfessorRepository;
 import com.softeer.reacton.domain.question.Question;
+import com.softeer.reacton.domain.question.QuestionRepository;
 import com.softeer.reacton.domain.request.Request;
+import com.softeer.reacton.domain.request.RequestRepository;
 import com.softeer.reacton.domain.schedule.Schedule;
 import com.softeer.reacton.domain.schedule.ScheduleRepository;
 import com.softeer.reacton.global.exception.BaseException;
@@ -31,6 +33,8 @@ public class ProfessorCourseService {
     private final ProfessorRepository professorRepository;
     private final CourseRepository courseRepository;
     private final ScheduleRepository scheduleRepository;
+    private final QuestionRepository questionRepository;
+    private final RequestRepository requestRepository;
     private final ProfessorCourseTransactionService professorCourseTransactionService;
 
     private static final int MAX_RETRIES = 10;
@@ -108,6 +112,9 @@ public class ProfessorCourseService {
 
         Course course = getCourseByProfessor(oauthId, courseId);
 
+        scheduleRepository.deleteAllByCourse(course);
+        questionRepository.deleteAllByCourse(course);
+        requestRepository.deleteAllByCourse(course);
         courseRepository.delete(course);
         courseRepository.flush();
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -116,7 +116,6 @@ public class ProfessorCourseService {
         questionRepository.deleteAllByCourse(course);
         requestRepository.deleteAllByCourse(course);
         courseRepository.delete(course);
-        courseRepository.flush();
 
         log.info("수업이 삭제되었습니다. : courseId = {}", courseId);
     }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseTransactionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseTransactionService.java
@@ -1,7 +1,7 @@
 package com.softeer.reacton.domain.course;
 
-import com.softeer.reacton.domain.course.dto.CourseRequest;
-import com.softeer.reacton.domain.professor.Professor;
+import com.softeer.reacton.domain.schedule.Schedule;
+import com.softeer.reacton.domain.schedule.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,10 +13,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProfessorCourseTransactionService {
 
     private final CourseRepository courseRepository;
+    private final ScheduleRepository scheduleRepository;
 
     @Transactional
-    public long saveCourse(CourseRequest request, Professor professor, int accessCode) {
-        Course course = Course.create(request, accessCode, professor);
-        return courseRepository.save(course).getId();
+    public long saveCourse(Course course) {
+        courseRepository.save(course);
+
+        for (Schedule schedule : course.getSchedules()) {
+            schedule.setCourse(course);
+            scheduleRepository.save(schedule);
+        }
+
+        return course.getId();
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorService.java
@@ -67,9 +67,9 @@ public class ProfessorService {
                 .orElseThrow(() -> new BaseException(ProfessorErrorCode.PROFESSOR_NOT_FOUND));
 
         courseRepository.findByProfessor(professor).forEach(course -> {
-            scheduleRepository.deleteByCourse((Course) course);
-            questionRepository.deleteByCourse((Course) course);
-            requestRepository.deleteByCourse((Course) course);
+            scheduleRepository.deleteAllByCourse((Course) course);
+            questionRepository.deleteAllByCourse((Course) course);
+            requestRepository.deleteAllByCourse((Course) course);
         });
         courseRepository.deleteByProfessor(professor);
         professorRepository.delete(professor);

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/QuestionRepository.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/QuestionRepository.java
@@ -4,5 +4,5 @@ import com.softeer.reacton.domain.course.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
-    void deleteByCourse(Course course);
+    void deleteAllByCourse(Course course);
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/RequestRepository.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/RequestRepository.java
@@ -4,5 +4,5 @@ import com.softeer.reacton.domain.course.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RequestRepository extends JpaRepository<Request, Long> {
-    void deleteByCourse(Course course);
+    void deleteAllByCourse(Course course);
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/schedule/Schedule.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/schedule/Schedule.java
@@ -1,6 +1,8 @@
 package com.softeer.reacton.domain.schedule;
 
 import com.softeer.reacton.domain.course.Course;
+import com.softeer.reacton.domain.course.dto.CourseRequest;
+import com.softeer.reacton.global.util.TimeUtil;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -31,10 +33,19 @@ public class Schedule {
     private Course course;
 
     @Builder
-    public Schedule(String day, LocalTime startTime, LocalTime endTime, Course course) {
+    private Schedule(String day, LocalTime startTime, LocalTime endTime, Course course) {
         this.day = day;
         this.startTime = startTime;
         this.endTime = endTime;
         this.course = course;
     }
+
+    public static Schedule create(CourseRequest.ScheduleRequest request, Course course) {
+        return Schedule.builder()
+                .day(request.getDay())
+                .startTime(TimeUtil.parseTime(request.getStartTime()))
+                .endTime(TimeUtil.parseTime(request.getEndTime()))
+                .course(course).build();
+    }
+
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/schedule/ScheduleRepository.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/schedule/ScheduleRepository.java
@@ -21,4 +21,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findSchedulesByCourse(Course course);
 
     void deleteByCourse(Course course);
+
+    void deleteAllByCourse(Course course);
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/schedule/ScheduleRepository.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/schedule/ScheduleRepository.java
@@ -20,7 +20,5 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             "ELSE 8 END, s.startTime ASC")
     List<Schedule> findSchedulesByCourse(Course course);
 
-    void deleteByCourse(Course course);
-
     void deleteAllByCourse(Course course);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#110 [BE] 수업 저장시 일정 데이터 저장 실패 

## 📝 작업 내용

### 수업 저장
- createCourse에서 Course 객체를 미리 생성하여, accessCode 발급 시마다 불필요한 객체 생성을 방지
- setAccessCode를 통해 accessCode만 변경하도록 수정
- Course 생성 시 Schedule 데이터를 명시적으로 추가하도록 개선

### 수업 수정
- scheduleRepository.deleteAllByCourse(course)를 통해 기존 일정 데이터를 먼저 삭제
- course.getSchedules().clear()로 영속성 컨텍스트에서도 제거
- 제거 후 새로운 Schedule을 만들어 명시적으로 저장

### ⭐️ 중요
- 선오님이 미리 `ScheduleRepository`에 `deleteByCourse`를 구현해놓으셨더라구요. 제가 생각하기엔 `deleteAllByCourse`가 더 명확하지 않나 라고 생각해서 우선 넣어뒀습니다. 리뷰하면서 같이 고려해주세요! 
- `deleteByCourse`와 `deleteAllByCourse`의 차이점이 뭘까 라고 고민해봤는데, 실제 동작은 비슷하게 되는거 같습니다. 다만 둘 차이를 알아보면서 **Bulk Delete**라는 것에 대해 알게 되었는데, 한번의 DELETE 문으로 여러개의 데이터를 삭제하는 방식이라고 합니다. JPA의 `@Modifying @Query`를 사용해서 직접 SQL을 실행하면 적용이 된다고 하는데 대량의 데이터를 삭제할때는 일반적인 `deleteAll()` 보다 성능이 좋다고 하니 참고하시면 좋을 것 같습니다. 제가 이번에 수정한 로직에서는 보통 2~3개 정도의 schedule만 삭제할거라고 예상되기에 간단한 `deleteAllByCourse`로만 구현해뒀습니다. 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Simplified course creation and update flows by removing extra steps, including eliminating the need for an access code during initial course setup.
  - Enhanced schedule management, enabling more reliable updates and bulk removals for course schedules.
  - Introduced a new method for creating `Schedule` instances, centralizing the instantiation logic.

- **Bug Fixes**
  - Improved deletion processes for associated entities, ensuring all related data is removed when a course or professor is deleted.

- **Refactor**
  - Streamlined internal processes for course and schedule handling to improve overall data consistency and operational reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->