### PR TITLE
[BE] 교수 전체 수업 조회 API 중 '오늘 수업 가져오기'의 정렬 방식 수정

### DIFF
--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -186,14 +186,11 @@ public class ProfessorCourseService {
 
     private List<CourseSummaryResponse> getTodayCoursesResponse(List<Course> allCourses) {
         String currentDay = TimeUtil.getCurrentDay();
-        LocalTime now = LocalTime.now();
 
         return allCourses.stream()
                 .filter(course -> hasScheduleInDay(course, currentDay))
                 .sorted(Comparator
-                        .comparing((Course course) -> isStartTimeAfterNow(course, currentDay, now))
-                        .reversed()
-                        .thenComparing(course -> getEarliestStartTime(course, currentDay)))
+                        .comparing(course -> getEarliestStartTime(course, currentDay)))
                 .map(course -> CourseSummaryResponse.of(course, getSchedulesForToday(course, currentDay)))
                 .collect(Collectors.toList());
     }
@@ -215,13 +212,6 @@ public class ProfessorCourseService {
                 .map(Schedule::getStartTime)
                 .min(Comparator.naturalOrder())
                 .orElse(LocalTime.MAX);
-    }
-
-    private boolean isStartTimeAfterNow(Course course, String day, LocalTime now) {
-        return course.getSchedules().stream()
-                .filter(schedule -> schedule.getDay().equals(day))
-                .map(Schedule::getStartTime)
-                .anyMatch(startTime -> startTime.isAfter(now));
     }
 
     private List<CourseScheduleResponse> getSchedulesForToday(Course course, String currentDay) {


### PR DESCRIPTION
## [BE] 교수 전체 수업 조회 API 중 '오늘 수업 가져오기'의 정렬 방식 수정

## #️⃣ 연관된 이슈

#109 

## 📝 작업 내용

교수의 '오늘 수업 조회' 시 정렬 방식 수정
> 프론트엔드 측과 논의 결과, '현재 시간 기준 정렬' 기능은 프론트엔드 측에서 수행하기로 결정되어 백엔드 측에서 구현한 정렬 방식을 수정하기로 결정
- 기존: 현재 시간 기준으로 아직 시작하지 않은 수업을 우선적으로 정렬, 그 후 시간 순으로 정렬
- 수정: 현재 시간과 관계없이 수업의 시작 시간을 기준으로 정렬

## 💬 리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the logic for displaying today's courses. Now, course schedules are consistently sorted based solely on start times, ensuring a clearer and more predictable course ordering for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->