### PR TITLE
[FE] 교수 강의 상세 정보 페이지 구현

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -7,7 +7,7 @@ import ProfessorSearch from './pages/professor/home/search/ProfessorSearch';
 import ProfessorLogin from './pages/professor/login/ProfessorLogin';
 import ProfessorRegister from './pages/professor/register/ProfessorRegister';
 import ProfessorProfile from './pages/professor/home/profile/ProfessorProfile';
-import ProfessorCourse from './pages/professor/course';
+import ProfessorCourse from './pages/professor/course/ProfessorCourse';
 import ProfessorClassRoom from './pages/professor/course/classroom';
 import StudentHome from './pages/student/home/StudentHome';
 import StudentCourse from './pages/student/course/StudentCourse';

--- a/front-end/src/pages/professor/course/ProfessorCourse.module.css
+++ b/front-end/src/pages/professor/course/ProfessorCourse.module.css
@@ -2,6 +2,7 @@
   width: 1920px;
   display: flex;
   flex-direction: column;
+  user-select: none;
 }
 
 .professorCourseHeader {
@@ -156,8 +157,7 @@
   outline: 1px solid var(--gray-300);
   border-radius: var(--large);
   box-shadow: 0px 0px 20px 0px rgba(162, 175, 208, 0.3);
-  padding: 40px;
-  padding-bottom: 25px;
+  padding: 35px 40px;
   gap: 20px;
 }
 

--- a/front-end/src/pages/professor/course/ProfessorCourse.module.css
+++ b/front-end/src/pages/professor/course/ProfessorCourse.module.css
@@ -119,3 +119,55 @@
   display: flex;
   gap: 10px;
 }
+
+.professorCourseBody {
+  background: radial-gradient(
+      45.11% 45.11% at 50% 54.89%,
+      rgba(0, 36, 224, 0.15) 0%,
+      rgba(0, 36, 224, 0) 100%
+    )
+    rgba(234, 241, 250, 1);
+}
+
+.bodyContainer {
+  width: auto;
+  display: flex;
+  flex-direction: column;
+  margin: 54px 274px;
+}
+
+.bodyHeader {
+  font: var(--web-header3-bold);
+  color: var(--gray-900);
+}
+
+.bodyContent {
+  display: flex;
+  gap: 20px;
+  margin-top: 24px;
+}
+
+.courseBodyContainer {
+  width: 676px;
+  height: 548px;
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  outline: 1px solid var(--gray-300);
+  border-radius: var(--large);
+  box-shadow: 0px 0px 20px 0px rgba(162, 175, 208, 0.3);
+  padding: 40px;
+  gap: 20px;
+}
+
+.courseBodyTitle {
+  font: var(--web-title3-bold);
+  color: var(--gray-800);
+}
+
+.bodyButtonContainer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 21px;
+  margin-top: 54px;
+}

--- a/front-end/src/pages/professor/course/ProfessorCourse.module.css
+++ b/front-end/src/pages/professor/course/ProfessorCourse.module.css
@@ -1,0 +1,121 @@
+.professorCourse {
+  width: 1920px;
+  display: flex;
+  flex-direction: column;
+}
+
+.professorCourseHeader {
+  width: 100%;
+  height: 221px;
+  background-color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+}
+
+.backButton {
+  position: absolute;
+  float: left;
+  left: 139px;
+  top: 43px;
+}
+
+.professorCourseHeaderContainer {
+  display: flex;
+  justify-content: space-between;
+  margin: 48px 274px;
+  width: 100%;
+}
+
+.professorCourseHeaderInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 13px;
+}
+
+.infoText {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.courseUniversity {
+  font: var(--web-body1-bold);
+  color: var(--sub-orange-500);
+}
+
+.courseTitle {
+  font: var(--web-title1-bold);
+  color: var(--sub-black-900);
+}
+
+.courseSubInfo {
+  display: flex;
+  align-items: center;
+}
+
+.courseSchedule {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+
+.clockIcon {
+  width: 18px;
+  height: 18px;
+}
+
+.subInfoText {
+  font: var(--web-body2-medium);
+  color: var(--gray-500);
+}
+
+.divider {
+  height: 16px;
+  border: 1.2px solid var(--gray-400);
+  margin: 0px 13px;
+}
+
+.coursePeople {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.peopleIcon {
+  width: 24px;
+  height: 24px;
+}
+
+.courseCategory {
+  width: 64px;
+  height: 34px;
+  margin-left: 18px;
+  font: var(--web-body3-bold);
+}
+
+.right {
+  display: flex;
+  gap: 46px;
+}
+
+.courseAccessCode {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 237px;
+  height: 60px;
+  outline: 2px solid var(--gray-300);
+  border-radius: 10px;
+}
+
+.accessCodeText {
+  font: var(--web-body2-medium);
+  color: var(--gray-700);
+}
+
+.headerButtonContainer {
+  display: flex;
+  gap: 10px;
+}

--- a/front-end/src/pages/professor/course/ProfessorCourse.module.css
+++ b/front-end/src/pages/professor/course/ProfessorCourse.module.css
@@ -157,6 +157,7 @@
   border-radius: var(--large);
   box-shadow: 0px 0px 20px 0px rgba(162, 175, 208, 0.3);
   padding: 40px;
+  padding-bottom: 25px;
   gap: 20px;
 }
 

--- a/front-end/src/pages/professor/course/ProfessorCourse.tsx
+++ b/front-end/src/pages/professor/course/ProfessorCourse.tsx
@@ -112,9 +112,9 @@ const ProfessorCourse = () => {
           </div>
         </div>
         <div className={S.professorCourseBody}>
-          <div className={S.professorCourseBodyContainer}>
-            <h2 className={S.professorCourseBodyHeader}>지난번 수업 데이터</h2>
-            <div className={S.professorCourseBodyContent}>
+          <div className={S.bodyContainer}>
+            <h2 className={S.bodyHeader}>지난번 수업 데이터</h2>
+            <div className={S.bodyContent}>
               <div className={S.courseBodyContainer}>
                 <h3 className={S.courseBodyTitle}>
                   💬 이전 수업에서 해결되지 못한 질문
@@ -123,12 +123,10 @@ const ProfessorCourse = () => {
               </div>
               <div className={S.courseBodyContainer}>
                 <h3 className={S.courseBodyTitle}>📊 이전 수업 반응 통계</h3>
-                <div className={S.courseBodyContent}>
-                  <CourseRequest requests={course?.requests || []} />
-                </div>
+                <CourseRequest requests={course?.requests || []} />
               </div>
             </div>
-            <div className={S.professorCourseBodyButtonContainer}>
+            <div className={S.bodyButtonContainer}>
               <TextButton
                 color="black"
                 size="web2"

--- a/front-end/src/pages/professor/course/ProfessorCourse.tsx
+++ b/front-end/src/pages/professor/course/ProfessorCourse.tsx
@@ -98,12 +98,16 @@ const ProfessorCourse = () => {
               </div>
               <div className={S.headerButtonContainer}>
                 <RecIconButton
-                  onButtonClick={() => handleEditCourse(course as CourseMeta)}
+                  onButtonClick={() =>
+                    course && handleEditCourse(course as CourseMeta)
+                  }
                   type="setting"
                   bg="gray"
                 />
                 <RecIconButton
-                  onButtonClick={() => handleDeleteCourse(course as CourseMeta)}
+                  onButtonClick={() =>
+                    course && handleDeleteCourse(course as CourseMeta)
+                  }
                   type="trash"
                   bg="red"
                 />

--- a/front-end/src/pages/professor/course/ProfessorCourse.tsx
+++ b/front-end/src/pages/professor/course/ProfessorCourse.tsx
@@ -26,11 +26,11 @@ const ProfessorCourse = () => {
     handleStartCourse,
     handleFileCourse,
   } = useCourseActions({ setModal, openModal, closeModal });
-  const handleClickBack = () => {
-    console.log('Click Back');
-  };
-
   const navigate = useNavigate();
+
+  const handleClickBack = () => {
+    navigate('/professor');
+  };
 
   useEffect(() => {
     async function getCourse() {

--- a/front-end/src/pages/professor/course/ProfessorCourse.tsx
+++ b/front-end/src/pages/professor/course/ProfessorCourse.tsx
@@ -1,0 +1,156 @@
+import CircleBackButton from '@/components/button/icon/CircleBackButton';
+import S from './ProfessorCourse.module.css';
+import RecIconButton from '@/components/button/icon/RecIconButton';
+import TextButton from '@/components/button/text/TextButton';
+import useCourseActions from '@/hooks/useCourseAction';
+import useModal from '@/hooks/useModal';
+import { useEffect, useState } from 'react';
+import { Course, CourseMeta } from '@/core/model';
+import ClockIcon from '@/assets/icons/clock.svg?react';
+import PeopleIcon from '@/assets/icons/people.svg?react';
+import { formatSchedule, getCourseColor } from '@/utils/util';
+import { courseRepository } from '@/di';
+import { useNavigate, useParams } from 'react-router';
+import CourseQuestion from './components/CourseQuestion';
+import CourseRequest from './components/CourseRequest';
+import CategoryChip from '@/components/chip/CategoryChip';
+
+const ProfessorCourse = () => {
+  const { courseId } = useParams<{ courseId: string }>();
+  const [course, setCourse] = useState<Course | null>(null);
+  const [modal, setModal] = useState<React.ReactNode | null>(null);
+  const { openModal, closeModal, Modal } = useModal();
+  const {
+    handleDeleteCourse,
+    handleEditCourse,
+    handleStartCourse,
+    handleFileCourse,
+  } = useCourseActions({ setModal, openModal, closeModal });
+  const handleClickBack = () => {
+    console.log('Click Back');
+  };
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    async function getCourse() {
+      try {
+        if (!courseId) {
+          navigate('/professor');
+          return;
+        }
+
+        const course = await courseRepository.getCourseById(parseInt(courseId));
+        setCourse(course);
+      } catch (error) {
+        alert(error);
+        navigate('/professor');
+      }
+    }
+
+    getCourse();
+  }, [courseId, navigate]);
+
+  return (
+    <>
+      <div className={S.professorCourse}>
+        <div className={S.professorCourseHeader}>
+          <div className={S.backButton}>
+            <CircleBackButton onButtonClick={handleClickBack} />
+          </div>
+          <div className={S.professorCourseHeaderContainer}>
+            <div className={S.professorCourseHeaderInfo}>
+              <div className={S.infoText}>
+                <h3 className={S.courseUniversity}>{course?.university}</h3>
+                <h1 className={S.courseTitle}>{course?.name}</h1>
+              </div>
+              <div className={S.courseSubInfo}>
+                <div className={S.courseSchedule}>
+                  <ClockIcon className={S.clockIcon} />
+                  <span className={S.subInfoText}>
+                    {course?.schedule.map((schedule, index) =>
+                      formatSchedule(
+                        schedule,
+                        index === course.schedule.length - 1
+                      )
+                    )}
+                  </span>
+                </div>
+                <div className={S.divider} />
+                <div className={S.coursePeople}>
+                  <PeopleIcon className={S.peopleIcon} />
+                  <span className={S.subInfoText}>{course?.capacity}명</span>
+                </div>
+                <div className={S.courseCategory}>
+                  <CategoryChip
+                    color={getCourseColor(course?.classType || '기타')}
+                    text={course?.classType || '기타'}
+                    isActive={true}
+                  />
+                </div>
+              </div>
+            </div>
+            <div className={S.right}>
+              <div className={S.courseAccessCode}>
+                <span className={S.accessCodeText}>
+                  입장코드 : {course?.accessCode}
+                </span>
+              </div>
+              <div className={S.headerButtonContainer}>
+                <RecIconButton
+                  onButtonClick={() => handleEditCourse(course as CourseMeta)}
+                  type="setting"
+                  bg="gray"
+                />
+                <RecIconButton
+                  onButtonClick={() => handleDeleteCourse(course as CourseMeta)}
+                  type="trash"
+                  bg="red"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className={S.professorCourseBody}>
+          <div className={S.professorCourseBodyContainer}>
+            <h2 className={S.professorCourseBodyHeader}>지난번 수업 데이터</h2>
+            <div className={S.professorCourseBodyContent}>
+              <div className={S.courseBodyContainer}>
+                <h3 className={S.courseBodyTitle}>
+                  💬 이전 수업에서 해결되지 못한 질문
+                </h3>
+                <CourseQuestion questions={course?.questions || []} />
+              </div>
+              <div className={S.courseBodyContainer}>
+                <h3 className={S.courseBodyTitle}>📊 이전 수업 반응 통계</h3>
+                <div className={S.courseBodyContent}>
+                  <CourseRequest requests={course?.requests || []} />
+                </div>
+              </div>
+            </div>
+            <div className={S.professorCourseBodyButtonContainer}>
+              <TextButton
+                color="black"
+                size="web2"
+                width="20.5rem"
+                height="5.0625rem"
+                text={course?.fileURL ? '파일 업로드 상태 수정' : '자료 업로드'}
+                onClick={() => handleFileCourse(course as CourseMeta)}
+              />
+              <TextButton
+                color="blue"
+                size="web2"
+                height="5.0625rem"
+                text="오늘 수업 시작하기"
+                onClick={() => handleStartCourse(course as CourseMeta)}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      {modal && <Modal>{modal}</Modal>}
+    </>
+  );
+};
+
+export default ProfessorCourse;

--- a/front-end/src/pages/professor/course/components/CourseQuestion.module.css
+++ b/front-end/src/pages/professor/course/components/CourseQuestion.module.css
@@ -3,7 +3,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  justify-content: space-between;
 }
 
 .page {

--- a/front-end/src/pages/professor/course/components/CourseQuestion.module.css
+++ b/front-end/src/pages/professor/course/components/CourseQuestion.module.css
@@ -1,0 +1,24 @@
+.container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 77px;
+}
+
+.pageNumber {
+  font: var(--web-body2-medium);
+  color: var(--gray-500);
+}
+
+.currentPage {
+  font: var(--web-body2-bold);
+  color: var(--gray-600);
+}

--- a/front-end/src/pages/professor/course/components/CourseQuestion.tsx
+++ b/front-end/src/pages/professor/course/components/CourseQuestion.tsx
@@ -1,15 +1,45 @@
 import { Question } from '@/core/model';
 import S from './CourseQuestion.module.css';
 import usePagination from '@/hooks/usePagination';
+import QuestionPage from './QuestionPage';
+import PaginationButton from '@/components/button/icon/PaginationButton';
 
 type CourseQuestionProps = {
   questions: Question[];
 };
 
 const CourseQuestion = ({ questions }: CourseQuestionProps) => {
-  const { prevPage, nextPage, PaginationDiv, page, totalPage } =
+  const { prevPage, nextPage, PaginationDiv, page, totalPages } =
     usePagination();
-  return <div>CourseQuestion</div>;
+  return (
+    <div className={S.container}>
+      <PaginationDiv>
+        {questions.length === 0 ? (
+          <QuestionPage question="" />
+        ) : (
+          questions.map((question, index) => (
+            <QuestionPage key={index} question={question.content} />
+          ))
+        )}
+      </PaginationDiv>
+      <div className={S.page}>
+        <PaginationButton
+          type="prev"
+          onButtonClick={prevPage}
+          isActive={page > 0}
+        />
+        <div className={S.pageNumber}>
+          <span className={S.currentPage}>{page + 1}</span> /{' '}
+          {Math.max(1, totalPages)}
+        </div>
+        <PaginationButton
+          type="next"
+          onButtonClick={nextPage}
+          isActive={page < totalPages - 1}
+        />
+      </div>
+    </div>
+  );
 };
 
 export default CourseQuestion;

--- a/front-end/src/pages/professor/course/components/CourseQuestion.tsx
+++ b/front-end/src/pages/professor/course/components/CourseQuestion.tsx
@@ -17,8 +17,8 @@ const CourseQuestion = ({ questions }: CourseQuestionProps) => {
         {questions.length === 0 ? (
           <QuestionPage question="" />
         ) : (
-          questions.map((question, index) => (
-            <QuestionPage key={index} question={question.content} />
+          questions.map((question) => (
+            <QuestionPage key={question.id} question={question.content} />
           ))
         )}
       </PaginationDiv>

--- a/front-end/src/pages/professor/course/components/CourseQuestion.tsx
+++ b/front-end/src/pages/professor/course/components/CourseQuestion.tsx
@@ -1,0 +1,15 @@
+import { Question } from '@/core/model';
+import S from './CourseQuestion.module.css';
+import usePagination from '@/hooks/usePagination';
+
+type CourseQuestionProps = {
+  questions: Question[];
+};
+
+const CourseQuestion = ({ questions }: CourseQuestionProps) => {
+  const { prevPage, nextPage, PaginationDiv, page, totalPage } =
+    usePagination();
+  return <div>CourseQuestion</div>;
+};
+
+export default CourseQuestion;

--- a/front-end/src/pages/professor/course/components/CourseRequest.module.css
+++ b/front-end/src/pages/professor/course/components/CourseRequest.module.css
@@ -1,0 +1,8 @@
+.courseRequest {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  gap: 18px;
+}

--- a/front-end/src/pages/professor/course/components/CourseRequest.tsx
+++ b/front-end/src/pages/professor/course/components/CourseRequest.tsx
@@ -1,12 +1,47 @@
+import S from './CourseRequest.module.css';
 import { Requests } from '@/core/model';
-import S from './CourseReaction.module.css';
+import BulbEmoji from '@/assets/icons/bulb-emoji.svg?react';
+import EarEmoji from '@/assets/icons/ear-emoji.svg?react';
+import MagnifierEmoji from '@/assets/icons/magnifier-emoji.svg?react';
+import WindEmoji from '@/assets/icons/wind-emoji.svg?react';
+import WishEmoji from '@/assets/icons/wish-emoji.svg?react';
+import RequestBar from './RequestBar';
 
 type CourseRequestProps = {
   requests: Requests | [];
 };
 
+const EmojiType = {
+  hard: WishEmoji,
+  fast: WindEmoji,
+  question: BulbEmoji,
+  size: MagnifierEmoji,
+  sound: EarEmoji,
+};
+
 const CourseRequest = ({ requests }: CourseRequestProps) => {
-  return <div>CourseReaction</div>;
+  const sortedRequests = requests.sort((a, b) => b.count - a.count);
+
+  return (
+    <div className={S.courseRequest}>
+      {sortedRequests.length === 0 ? (
+        <div className={S.requestBar}>
+          <p>No requests yet</p>
+        </div>
+      ) : (
+        sortedRequests.map((request, index) => (
+          <RequestBar
+            key={index}
+            index={index}
+            title={request.type.title}
+            Emoji={EmojiType[request.type.kind]}
+            count={request.count}
+            percentage={(request.count / sortedRequests[0].count) * 100}
+          />
+        ))
+      )}
+    </div>
+  );
 };
 
 export default CourseRequest;

--- a/front-end/src/pages/professor/course/components/CourseRequest.tsx
+++ b/front-end/src/pages/professor/course/components/CourseRequest.tsx
@@ -1,5 +1,12 @@
 import S from './CourseRequest.module.css';
-import { Requests } from '@/core/model';
+import {
+  Requests,
+  RequestFast,
+  RequestHard,
+  RequestQuestion,
+  RequestSize,
+  RequestSound,
+} from '@/core/model';
 import BulbEmoji from '@/assets/icons/bulb-emoji.svg?react';
 import EarEmoji from '@/assets/icons/ear-emoji.svg?react';
 import MagnifierEmoji from '@/assets/icons/magnifier-emoji.svg?react';
@@ -19,15 +26,54 @@ const EmojiType = {
   sound: EarEmoji,
 };
 
+const getRequestPercentage = (count: number, max: number) => {
+  if (max === 0) return 0;
+  return (count / max) * 100;
+};
+
 const CourseRequest = ({ requests }: CourseRequestProps) => {
   const sortedRequests = requests.sort((a, b) => b.count - a.count);
 
   return (
     <div className={S.courseRequest}>
       {sortedRequests.length === 0 ? (
-        <div className={S.requestBar}>
-          <p>No requests yet</p>
-        </div>
+        <>
+          <RequestBar
+            index={0}
+            title={RequestSize.title}
+            Emoji={EmojiType.size}
+            count={0}
+            percentage={0}
+          />
+          <RequestBar
+            index={1}
+            title={RequestQuestion.title}
+            Emoji={EmojiType.question}
+            count={0}
+            percentage={0}
+          />
+          <RequestBar
+            index={2}
+            title={RequestHard.title}
+            Emoji={EmojiType.hard}
+            count={0}
+            percentage={0}
+          />
+          <RequestBar
+            index={3}
+            title={RequestSound.title}
+            Emoji={EmojiType.sound}
+            count={0}
+            percentage={0}
+          />
+          <RequestBar
+            index={4}
+            title={RequestFast.title}
+            Emoji={EmojiType.fast}
+            count={0}
+            percentage={0}
+          />
+        </>
       ) : (
         sortedRequests.map((request, index) => (
           <RequestBar
@@ -36,7 +82,10 @@ const CourseRequest = ({ requests }: CourseRequestProps) => {
             title={request.type.title}
             Emoji={EmojiType[request.type.kind]}
             count={request.count}
-            percentage={(request.count / sortedRequests[0].count) * 100}
+            percentage={getRequestPercentage(
+              request.count,
+              sortedRequests[0].count
+            )}
           />
         ))
       )}

--- a/front-end/src/pages/professor/course/components/CourseRequest.tsx
+++ b/front-end/src/pages/professor/course/components/CourseRequest.tsx
@@ -1,0 +1,12 @@
+import { Requests } from '@/core/model';
+import S from './CourseReaction.module.css';
+
+type CourseRequestProps = {
+  requests: Requests | [];
+};
+
+const CourseRequest = ({ requests }: CourseRequestProps) => {
+  return <div>CourseReaction</div>;
+};
+
+export default CourseRequest;

--- a/front-end/src/pages/professor/course/components/QuestionPage.module.css
+++ b/front-end/src/pages/professor/course/components/QuestionPage.module.css
@@ -17,6 +17,7 @@
   font: var(--web-body-list20-regular);
   color: var(--gray-600);
   word-break: break-all;
+  user-select: text;
 }
 
 .noQuestion > .question {

--- a/front-end/src/pages/professor/course/components/QuestionPage.module.css
+++ b/front-end/src/pages/professor/course/components/QuestionPage.module.css
@@ -1,0 +1,25 @@
+.page {
+  width: 100%;
+  height: 372px;
+  background-color: var(--bg);
+  padding: 24px 32px;
+  border-radius: var(--medium);
+}
+
+.noQuestion {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+}
+
+.question {
+  font: var(--web-body-list20-regular);
+  color: var(--gray-600);
+  word-break: break-all;
+}
+
+.noQuestion > .question {
+  font: var(--web-body-list20-regular);
+  color: var(--gray-400);
+}

--- a/front-end/src/pages/professor/course/components/QuestionPage.tsx
+++ b/front-end/src/pages/professor/course/components/QuestionPage.tsx
@@ -1,0 +1,19 @@
+import S from './QuestionPage.module.css';
+
+type QuestionPageProps = {
+  question: string;
+};
+
+const QuestionPage = ({ question }: QuestionPageProps) => {
+  return question === '' ? (
+    <div className={`${S.page} ${S.noQuestion}`}>
+      <p className={S.question}>답변되지 않은 질문이 없습니다.</p>
+    </div>
+  ) : (
+    <div className={S.page}>
+      <p className={S.question}>{question}</p>
+    </div>
+  );
+};
+
+export default QuestionPage;

--- a/front-end/src/pages/professor/course/components/RequestBar.module.css
+++ b/front-end/src/pages/professor/course/components/RequestBar.module.css
@@ -1,0 +1,89 @@
+.requestBar {
+  width: 100%;
+  height: 100%;
+  background-color: var(--bg);
+  outline: 1px solid var(--gray-400);
+  border-radius: 24px 100px 100px 24px;
+  position: relative;
+  overflow: hidden;
+}
+
+.percentage {
+  height: 100%;
+  position: absolute;
+  z-index: 2;
+  background-color: var(--gray-300);
+  border-radius: 0px 100px 100px 0px;
+  overflow: hidden;
+}
+
+.first > .percentage,
+.second > .percentage {
+  background-color: var(--sub-green-500);
+}
+
+.content {
+  position: absolute;
+  z-index: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 596px;
+  height: 100%;
+}
+
+.main {
+  display: flex;
+  align-items: center;
+  margin-left: 13px;
+  gap: 11px;
+}
+
+.emojiBackground {
+  width: 38px;
+  height: 38px;
+  background-color: rgba(255, 255, 255, 0.8);
+  border-radius: 50%;
+  outline: 1px solid var(--gray-300);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.emoji {
+  width: 20px;
+  height: 20px;
+}
+
+.title {
+  font: var(--web-title4-medium);
+  color: var(--gray-500);
+}
+
+.first .title,
+.second .title {
+  font: var(--web-title4-medium);
+  color: var(--sub-green-500);
+  text-shadow: 0px 0px 10px rgba(0, 0, 0, 0.25);
+}
+
+.first .percentage .title,
+.second .percentage .title {
+  color: white;
+}
+
+.count {
+  font: var(--web-title4-bold);
+  color: var(--gray-400);
+  margin-right: 36px;
+}
+
+.first .count,
+.second .count {
+  color: var(--sub-green-500);
+}
+
+.first .percentage .count,
+.second .percentage .count {
+  color: white;
+}

--- a/front-end/src/pages/professor/course/components/RequestBar.module.css
+++ b/front-end/src/pages/professor/course/components/RequestBar.module.css
@@ -1,29 +1,46 @@
-.requestBar {
+.container {
+  width: 100%;
+  height: 100%;
+  outline: 1px solid var(--gray-400);
+  border-radius: 24px 100px 100px 24px;
+  overflow: hidden;
+}
+
+.wrapper {
   width: 100%;
   height: 100%;
   background-color: var(--bg);
-  outline: 1px solid var(--gray-400);
-  border-radius: 24px 100px 100px 24px;
   position: relative;
   overflow: hidden;
+  isolation: isolate;
+}
+
+.active.wrapper::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--sub-green-500);
+  border-radius: 0 100px 100px 0;
+  mix-blend-mode: screen;
 }
 
 .percentage {
   height: 100%;
   position: absolute;
-  z-index: 2;
   background-color: var(--gray-300);
   border-radius: 0 100px 100px 0;
   overflow: hidden;
 }
 
 .active > .percentage {
-  background-color: var(--sub-green-500);
+  background-color: black;
 }
 
 .content {
   position: absolute;
-  z-index: 1;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -47,6 +64,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  z-index: 1;
 }
 
 .emoji {
@@ -60,12 +78,9 @@
 }
 
 .active .title {
-  color: var(--sub-green-500);
-  text-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
-}
-
-.active .percentage .title {
   color: white;
+  mix-blend-mode: difference;
+  text-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
 }
 
 .count {
@@ -75,9 +90,6 @@
 }
 
 .active .count {
-  color: var(--sub-green-500);
-}
-
-.active .percentage .count {
   color: white;
+  mix-blend-mode: difference;
 }

--- a/front-end/src/pages/professor/course/components/RequestBar.module.css
+++ b/front-end/src/pages/professor/course/components/RequestBar.module.css
@@ -13,12 +13,11 @@
   position: absolute;
   z-index: 2;
   background-color: var(--gray-300);
-  border-radius: 0px 100px 100px 0px;
+  border-radius: 0 100px 100px 0;
   overflow: hidden;
 }
 
-.first > .percentage,
-.second > .percentage {
+.active > .percentage {
   background-color: var(--sub-green-500);
 }
 
@@ -60,15 +59,12 @@
   color: var(--gray-500);
 }
 
-.first .title,
-.second .title {
-  font: var(--web-title4-medium);
+.active .title {
   color: var(--sub-green-500);
-  text-shadow: 0px 0px 10px rgba(0, 0, 0, 0.25);
+  text-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
 }
 
-.first .percentage .title,
-.second .percentage .title {
+.active .percentage .title {
   color: white;
 }
 
@@ -78,12 +74,10 @@
   margin-right: 36px;
 }
 
-.first .count,
-.second .count {
+.active .count {
   color: var(--sub-green-500);
 }
 
-.first .percentage .count,
-.second .percentage .count {
+.active .percentage .count {
   color: white;
 }

--- a/front-end/src/pages/professor/course/components/RequestBar.tsx
+++ b/front-end/src/pages/professor/course/components/RequestBar.tsx
@@ -9,30 +9,6 @@ type RequestBarProps = {
   percentage: number;
 };
 
-type RequestBarContentProps = {
-  title: string;
-  Emoji: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
-  count: number;
-};
-
-const RequestBarContent = ({ title, Emoji, count }: RequestBarContentProps) => {
-  return (
-    <div className={S.content}>
-      <div className={S.main}>
-        <div className={S.emojiBackground}>
-          <Emoji className={S.emoji} />
-        </div>
-        <div className={S.title}>
-          <span className={S.titleGreen}>{title}</span>
-        </div>
-      </div>
-      <div className={S.count}>
-        <span>{count}</span>
-      </div>
-    </div>
-  );
-};
-
 const RequestBar = ({
   index,
   title,
@@ -42,14 +18,26 @@ const RequestBar = ({
 }: RequestBarProps) => {
   const displayTitle = title.slice(0, -2);
   return (
-    <div className={`${S.requestBar} ${index < 2 && S.active}`}>
-      <div
-        className={S.percentage}
-        style={{ width: `max(${percentage}%, 18px)` }}
-      >
-        <RequestBarContent title={displayTitle} Emoji={Emoji} count={count} />
+    <div className={S.container}>
+      <div className={`${S.wrapper} ${index < 2 && S.active}`}>
+        <div
+          className={S.percentage}
+          style={{ width: `max(${percentage}%, 18px)` }}
+        />
+        <div className={S.content}>
+          <div className={S.main}>
+            <div className={S.emojiBackground}>
+              <Emoji className={S.emoji} />
+            </div>
+            <div className={S.title}>
+              <span className={S.titleGreen}>{displayTitle}</span>
+            </div>
+          </div>
+          <div className={S.count}>
+            <span>{count}</span>
+          </div>
+        </div>
       </div>
-      <RequestBarContent title={displayTitle} Emoji={Emoji} count={count} />
     </div>
   );
 };

--- a/front-end/src/pages/professor/course/components/RequestBar.tsx
+++ b/front-end/src/pages/professor/course/components/RequestBar.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import S from './RequestBar.module.css';
+
+type RequestBarProps = {
+  index: number;
+  title: string;
+  Emoji: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  count: number;
+  percentage: number;
+};
+
+type RequestBarContentProps = {
+  title: string;
+  Emoji: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  count: number;
+};
+
+const RequestBarContent = ({ title, Emoji, count }: RequestBarContentProps) => {
+  return (
+    <div className={S.content}>
+      <div className={S.main}>
+        <div className={S.emojiBackground}>
+          <Emoji className={S.emoji} />
+        </div>
+        <div className={S.title}>
+          <span className={S.titleGreen}>{title}</span>
+        </div>
+      </div>
+      <div className={S.count}>
+        <span>{count}</span>
+      </div>
+    </div>
+  );
+};
+
+const RequestBar = ({
+  index,
+  title,
+  Emoji,
+  count,
+  percentage,
+}: RequestBarProps) => {
+  const displayTitle = title.slice(0, -2);
+  return (
+    <div
+      className={`${S.requestBar} ${index === 0 ? S.first : ''} ${index === 1 ? S.second : ''}`}
+    >
+      <div
+        className={S.percentage}
+        style={{ width: percentage === 0 ? '18px' : `${percentage}%` }}
+      >
+        <RequestBarContent title={displayTitle} Emoji={Emoji} count={count} />
+      </div>
+      <RequestBarContent title={displayTitle} Emoji={Emoji} count={count} />
+    </div>
+  );
+};
+
+export default RequestBar;

--- a/front-end/src/pages/professor/course/components/RequestBar.tsx
+++ b/front-end/src/pages/professor/course/components/RequestBar.tsx
@@ -42,12 +42,10 @@ const RequestBar = ({
 }: RequestBarProps) => {
   const displayTitle = title.slice(0, -2);
   return (
-    <div
-      className={`${S.requestBar} ${index === 0 ? S.first : ''} ${index === 1 ? S.second : ''}`}
-    >
+    <div className={`${S.requestBar} ${index < 2 && S.active}`}>
       <div
         className={S.percentage}
-        style={{ width: percentage === 0 ? '18px' : `${percentage}%` }}
+        style={{ width: `max(${percentage}%, 18px)` }}
       >
         <RequestBarContent title={displayTitle} Emoji={Emoji} count={count} />
       </div>

--- a/front-end/src/pages/professor/course/index.tsx
+++ b/front-end/src/pages/professor/course/index.tsx
@@ -1,9 +1,0 @@
-const ProfessorCourse: React.FC = () => {
-  return (
-    <div>
-      <h1>Course</h1>
-    </div>
-  );
-};
-
-export default ProfessorCourse;

--- a/front-end/src/pages/professor/home/components/CourseCard.tsx
+++ b/front-end/src/pages/professor/home/components/CourseCard.tsx
@@ -13,6 +13,7 @@ import {
   isSoon,
   getCourseColor,
   TimeType,
+  formatSchedule,
 } from '@/utils/util';
 import MeatBallMenu from './MeatBallMenu';
 
@@ -26,14 +27,6 @@ type CourseCardProps = {
   onDetailCourse: (course: CourseMeta) => void;
   onFileCourse: (course: CourseMeta) => void;
 };
-
-const renderSchedule = (scheduleList: CourseMeta['schedule']) =>
-  scheduleList.map((schedule, index) => (
-    <span key={schedule.day}>
-      {schedule.day} {schedule.start} - {schedule.end}
-      {index < scheduleList.length - 1 && ', '}
-    </span>
-  ));
 
 const RenderButtonContainer = (
   width: string,
@@ -170,7 +163,14 @@ const CourseCard = ({
               <div className={S.metaItem}>
                 <ClockIcon className={S.metaIcon} />
                 <span className={S.metaText}>
-                  {renderSchedule(course.schedule)}
+                  {course.schedule.map((schedule, index) => (
+                    <span key={schedule.day}>
+                      {formatSchedule(
+                        schedule,
+                        index === course.schedule.length - 1
+                      )}
+                    </span>
+                  ))}
                 </span>
               </div>
               <div className={S.metaItem}>
@@ -231,7 +231,14 @@ const CourseCard = ({
               <div className={S.metaItem}>
                 <ClockIcon className={S.metaIcon} />
                 <span className={S.metaText}>
-                  {renderSchedule(course.schedule)}
+                  {course.schedule.map((schedule, index) => (
+                    <span key={schedule.day}>
+                      {formatSchedule(
+                        schedule,
+                        index === course.schedule.length - 1
+                      )}
+                    </span>
+                  ))}
                 </span>
               </div>
               <div className={S.metaItem}>

--- a/front-end/src/utils/util.ts
+++ b/front-end/src/utils/util.ts
@@ -1,4 +1,4 @@
-import { CourseMeta } from '@/core/model';
+import { CourseMeta, Schedule } from '@/core/model';
 
 const imageType = ['image/png', 'image/jpeg', 'image/jpg', 'image/webp'];
 
@@ -96,3 +96,7 @@ export function createCourseGroup(courses: CourseMeta[], size: number) {
 
 export const CourseDay = ['월', '화', '수', '목', '금', '토', '일'];
 export const CourseType = ['전공', '교양', '기타'];
+
+export const formatSchedule = (schedule: Schedule, isEnd: boolean) => {
+  return `${schedule.day} ${schedule.start} - ${schedule.end}${isEnd ? '' : ', '}`;
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #128 

## 📝 작업 내용

- 교수 강의 상세 정보 페이지 구현

<img width="1470" alt="스크린샷 2025-02-16 오전 8 39 59" src="https://github.com/user-attachments/assets/9c8dccd7-7a35-49f5-a98c-dbef54540155" />

## 💬 리뷰 요구사항(선택)

- 요청하기 통계를 보여줄 때 1, 2등이 여러개일 경우 어떻게 보여주는게 좋을까요?
  1. 단순히 정렬 후 인덱스에서 0, 1번만 하이라이트
  2. count 개수가 중복된 것을 순위에 반영
    - 1등이 여러 개이면 1등인 것들 전부 하이라이트, 나머지 회색
    - 2등이 여러 개이면 1등 + 2등인 것들 전부 하이라이트, 나머지 회색


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a comprehensive interface for managing courses, with detailed views, pagination for questions, and interactive requests.
  - Added a new `CourseQuestion` component for displaying paginated questions.
  - Introduced a `RequestBar` component to visually represent course requests with emoji indicators.

- **Style**
  - Enhanced styles for the Professor Course page and its components, improving layout, presentation, and user interaction.
  - Implemented new CSS modules for better organization and maintenance of styles across course-related components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->