### PR TITLE
[BE] 리다이렉트시 쿠키 삭제되는 문제 

### DIFF
--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +27,9 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class ProfessorCourseController {
     private final ProfessorCourseService professorCourseService;
+
+    @Value("${frontend.base-url}")
+    private String FRONTEND_BASE_URL;
 
     @GetMapping("/active")
     @Operation(
@@ -47,7 +51,7 @@ public class ProfessorCourseController {
         } else {
             log.debug("활성화된 수업이 존재하지 않습니다.");
             return ResponseEntity.status(HttpStatus.SEE_OTHER)
-                    .header(HttpHeaders.LOCATION, "/professor")
+                    .header(HttpHeaders.LOCATION, FRONTEND_BASE_URL+"professor")
                     .build();
         }
     }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -31,6 +32,9 @@ public class ProfessorController {
 
     private final ProfessorService professorService;
     private final CookieConfig cookieConfig;
+
+    @Value("${frontend.base-url}")
+    private String FRONTEND_BASE_URL;
 
     @GetMapping
     @Operation(
@@ -165,7 +169,7 @@ public class ProfessorController {
 
         return ResponseEntity
                 .status(HttpStatus.SEE_OTHER)
-                .header(HttpHeaders.LOCATION, "/professor")
+                .header(HttpHeaders.LOCATION, FRONTEND_BASE_URL + "professor")
                 .header(HttpHeaders.SET_COOKIE, jwtCookie.toString())
                 .build();
     }
@@ -190,7 +194,7 @@ public class ProfessorController {
 
         return ResponseEntity
                 .status(HttpStatus.SEE_OTHER)
-                .header(HttpHeaders.LOCATION, "/")
+                .header(HttpHeaders.LOCATION, FRONTEND_BASE_URL)
                 .header(HttpHeaders.SET_COOKIE, jwtCookie.toString())
                 .build();
     }
@@ -218,7 +222,7 @@ public class ProfessorController {
 
         return ResponseEntity
                 .status(HttpStatus.SEE_OTHER)
-                .header(HttpHeaders.LOCATION, "/")
+                .header(HttpHeaders.LOCATION, FRONTEND_BASE_URL)
                 .header(HttpHeaders.SET_COOKIE, jwtCookie.toString())
                 .build();
     }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorController.java
@@ -157,6 +157,7 @@ public class ProfessorController {
                 .path("/")
                 .maxAge(cookieConfig.getAuthExpiration())
                 .sameSite("Strict")
+                .domain(cookieConfig.getDomain())
                 .build();
 
         log.debug("회원가입에 성공했습니다 : name = {}", name);
@@ -184,6 +185,7 @@ public class ProfessorController {
                 .path("/")
                 .maxAge(0)
                 .sameSite("Strict")
+                .domain(cookieConfig.getDomain())
                 .build();
 
         return ResponseEntity
@@ -211,6 +213,7 @@ public class ProfessorController {
                 .path("/")
                 .maxAge(0)
                 .sameSite("Strict")
+                .domain(cookieConfig.getDomain())
                 .build();
 
         return ResponseEntity

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorController.java
@@ -157,7 +157,7 @@ public class ProfessorController {
         String newAccessToken = professorService.signUp(name, profileImageFile, oauthId, email, isSignedUp);
         ResponseCookie jwtCookie = ResponseCookie.from("access_token", newAccessToken)
                 .httpOnly(true)
-                .secure(false) // TODO : HTTP에서도 쿠키 전송 가능하도록 설정 (배포 환경에서는 true로 변경)
+                .secure(true)
                 .path("/")
                 .maxAge(cookieConfig.getAuthExpiration())
                 .sameSite("Strict")
@@ -185,7 +185,7 @@ public class ProfessorController {
     public ResponseEntity<Void> logout() {
         ResponseCookie jwtCookie = ResponseCookie.from("access_token", "")
                 .httpOnly(true)
-                .secure(false) // TODO : HTTP에서도 쿠키 전송 가능하도록 설정 (배포 환경에서는 true로 변경)
+                .secure(true)
                 .path("/")
                 .maxAge(0)
                 .sameSite("Strict")
@@ -213,7 +213,7 @@ public class ProfessorController {
 
         ResponseCookie jwtCookie = ResponseCookie.from("access_token", "")
                 .httpOnly(true)
-                .secure(false) // TODO : HTTP에서도 쿠키 전송 가능하도록 설정 (배포 환경에서는 true로 변경)
+                .secure(true)
                 .path("/")
                 .maxAge(0)
                 .sameSite("Strict")

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/config/CookieConfig.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/config/CookieConfig.java
@@ -9,10 +9,13 @@ import org.springframework.stereotype.Component;
 public class CookieConfig {
     private final int authExpiration;
     private final int signupExpiration;
+    private final String domain;
 
     public CookieConfig(@Value("${cookie.auth.expiration}") int authExpiration,
-                        @Value("${cookie.signup.expiration}") int signupExpiration) {
+                        @Value("${cookie.signup.expiration}") int signupExpiration,
+                        @Value("${cookie.domain}") String domain ) {
         this.authExpiration = authExpiration;
         this.signupExpiration = signupExpiration;
+        this.domain = domain;
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/jwt/JwtAuthenticationFilter.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/jwt/JwtAuthenticationFilter.java
@@ -31,7 +31,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final List<String> WHITE_LIST_URLS = List.of(
             "/auth/google/url",
-            "/auth/google/callback"
+            "/auth/google/callback",
+            "/swagger-ui",
+            "/swagger-ui/**",
+            "/v3/api-docs",
+            "/v3/api-docs/**"
     );
 
     @Override
@@ -40,6 +44,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         log.debug("JWT 토큰 관련 필터 작업을 수행합니다.");
 
         String requestUri = request.getRequestURI();
+        log.debug("URL : " + requestUri);
+        if (isWhiteListed("/v3/api-docs/swagger-config")) log.debug("/v3/api-docs 있음");
         if (isWhiteListed(requestUri)) {
             log.debug("필터를 적용하지 않는 URL 주소입니다. : requestUri = {}", requestUri);
             chain.doFilter(request, response);

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthController.java
@@ -65,6 +65,7 @@ public class OAuthController {
                 .path("/")
                 .maxAge(isSignedUp ? cookieConfig.getAuthExpiration() : cookieConfig.getSignupExpiration())
                 .sameSite("Strict")
+                .domain(cookieConfig.getDomain())
                 .build();
 
         log.debug("JWT 쿠키 설정이 완료되었습니다. : isSignedUp = {}", isSignedUp);

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -21,8 +22,10 @@ import org.springframework.web.bind.annotation.*;
 public class OAuthController {
 
     private final OAuthService oauthService;
-
     private final CookieConfig cookieConfig;
+
+    @Value("${frontend.base-url}")
+    private String FRONTEND_BASE_URL;
 
     @GetMapping("/{provider}/url")
     @Operation(
@@ -37,7 +40,7 @@ public class OAuthController {
 
         log.info("OAuth 로그인 URL을 생성했습니다.");
 
-        return ResponseEntity.status(HttpStatus.FOUND)
+        return ResponseEntity.status(HttpStatus.SEE_OTHER)
                 .header(HttpHeaders.LOCATION, oauthLoginUrl)
                 .build();
     }
@@ -72,9 +75,9 @@ public class OAuthController {
 
         ResponseEntity.BodyBuilder response = ResponseEntity.status(HttpStatus.SEE_OTHER)
                 .header(HttpHeaders.SET_COOKIE, jwtCookie.toString());
+        log.debug(FRONTEND_BASE_URL);
+        String redirectUrl = isSignedUp ? "professor/loading" : "professor/register";
 
-        String redirectUrl = isSignedUp ? "/professor/loading" : "/professor/register";
-
-        return response.header(HttpHeaders.LOCATION, redirectUrl).build();
+        return response.header(HttpHeaders.LOCATION, FRONTEND_BASE_URL + redirectUrl).build();
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/oauth/OAuthController.java
@@ -64,13 +64,12 @@ public class OAuthController {
 
         ResponseCookie jwtCookie = ResponseCookie.from("access_token", loginResult.getAccessToken())
                 .httpOnly(true)
-                .secure(false) // TODO : HTTP에서도 쿠키 전송 가능하도록 설정 (배포 환경에서는 true로 변경)
+                .secure(true)
                 .path("/")
                 .maxAge(isSignedUp ? cookieConfig.getAuthExpiration() : cookieConfig.getSignupExpiration())
                 .sameSite("Strict")
                 .domain(cookieConfig.getDomain())
                 .build();
-
         log.debug("JWT 쿠키 설정이 완료되었습니다. : isSignedUp = {}", isSignedUp);
 
         ResponseEntity.BodyBuilder response = ResponseEntity.status(HttpStatus.SEE_OTHER)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#137 [BE] 리다이렉트시 쿠키 삭제되는 문제 

## 📝 작업 내용

### 문제 상황 설명
로그인이나 회원가입 등 몇몇 API에서 응답에 상태 코드로 300번대를, Location 헤더에 리다이렉트 주소를 지정해주었습니다. EC2 서버에 배포된 상태에서 프론트 로컬에서 테스트해보는데 리다이렉트 주소가 EC2 서버의 도메인 주소와 달라 쿠키가 넘어가지 않는 문제가 발생했습니다. 

### 해결
[리다이렉트시 쿠키 없어지는 문제 해결](https://github.com/softeer5th/Team3-PowerPenguin/wiki/%EB%A6%AC%EB%8B%A4%EC%9D%B4%EB%A0%89%ED%8A%B8%EC%8B%9C-%EC%BF%A0%ED%82%A4-%EC%97%86%EC%96%B4%EC%A7%80%EB%8A%94-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0)
-> 결론적으로 프론트와 도메인을 통일했습니다! 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled dynamic, configurable redirection for course-related and account management flows, improving navigation consistency.
	- Enhanced OAuth login and callback behavior with refined redirection, streamlining the user authentication experience.
	- Upgraded cookie management to enforce secure transmission and proper domain settings, bolstering session security.
	- Added support for API documentation endpoints to bypass JWT authentication, enhancing accessibility for developers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->