### PR TITLE
[FE] 로컬 도메인 세팅 

### DIFF
--- a/front-end/.gitignore
+++ b/front-end/.gitignore
@@ -24,3 +24,5 @@ dist-ssr
 *.sw?
 
 .env*
+
+*.pem

--- a/front-end/vite.config.ts
+++ b/front-end/vite.config.ts
@@ -1,19 +1,29 @@
+import fs from 'fs';
+import path from 'path';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import svgr from 'vite-plugin-svgr';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), svgr(), tsconfigPaths()],
   server: {
-    host: true,
+    host: 'front.softeer-reacton.shop',
+    https: {
+      key: fs.readFileSync(
+        path.resolve(__dirname, 'front.softeer-reacton.shop-key.pem')
+      ),
+      cert: fs.readFileSync(
+        path.resolve(__dirname, 'front.softeer-reacton.shop.pem')
+      ),
+    },
     proxy: {
       '/api': {
-        target: 'http://softeer-reacton.shop:8080/',
+        target: 'https://softeer-reacton.shop',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ''),
       },
     },
+    port: 5173,
   },
 });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #139 

## 📝 작업 내용

- 로컬 도메인 사용을 위한 vite.config.ts 수정
- .pem 형식 파일 gitignore 추가

## 💬 리뷰 요구사항(선택)

로컬 환경에서 도메인을 사용하려면 다음의 설정 과정이 필요합니다

### 1. localhost 도메인 이름을 호스팅 도메인으로 변경

`/etc/hosts` 파일에서 IP가 127.0.0.1인 localhost를 호스팅 도메인(`front.softeer-reacton.shop`)으로 변경합니다. 

### 2. SSL 인증서 발급

HTTPS를 사용하기 위해 SSL 인증서를 발급받습니다. Self-Signed 인증서를 사용할 수도 있으나, 브라우저에서는 보안 경고가 뜨게 됩니다. SSL 인증서를 발급받는 것이 어렵지 않으니 인증서를 발급받아 사용하도록 하겠습니다.

1. mkcert 설치
`brew install mkcert`
2. 로컬 CA 설치
`mkcert -install`
3. 도메인에 맞게 인증서 생성
`mkcert <DOMAIN_NAME>`
저희 호스팅 도메인에 맞게 `mkcert front.softeer-reacton.shop`으로 인증서를 생성하시면 `front.softeer-reacton.shop-key.pem`과 `front.softeer-reacton.shop.pem` 파일이 생성됩니다. 명령어 사용시 위치하고 있는 디렉토리에 파일이 생성되므로 front-end 디렉토리에서 실행하면 됩니다.
4. 적용 확인
작업 후 `https://front.softeer-reacton.shop:5173`으로 접속할 시 메인 홈 페이지가 나오면 정상적으로 적용된 것입니다. 만약 접속되지 않는다면 먼저 다음을 확인해보고 안된다면 검색해보고 찾아보셔야 할 거 같습니다
- 이번 설정 파일 적용 이후부터는 http 접속이 불가합니다. https로 접속하였는지 확인해주세요
- `ERR_TLS_CERT_ALTNAME_INVALID`가 나온다면 인증서가 제대로 만들어지지 않았을 가능성이 있습니다. 
`openssl x509 -in front.softeer-reacton.shop.pem -text -noout | grep -A1 "Subject Alternative Name"` 명령을 통해 DNS가 제대로 설정되어 있는지 확인해주시고 만약 제대로 설정되어 있지 않다면 
`mkcert -cert-file front.softeer-reacton.shop.pem -key-file front.softeer-reacton.shop-key.pem front.softeer-reacton.shop` 명령으로 새로 인증서를 발급해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated ignore settings to automatically exclude certificate files from tracking.
  - Refined server configuration by specifying a custom host, enabling secure HTTPS connections with dedicated certificates, and adjusting proxy and port settings for improved connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->