### PR TITLE
[BE] 메인 프로젝트 CI/CD 구축

### DIFF
--- a/.github/workflows/reacton-ci-cd.yml
+++ b/.github/workflows/reacton-ci-cd.yml
@@ -1,0 +1,76 @@
+name: Deploy ReactON
+
+on:
+  push:
+    branches: [ "dev", "main" ]
+    paths:
+      - "back-end/reacton/**"
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Make application.properties (without sensitive data)
+        run: |
+          cd back-end/reacton/src/main/resources
+          touch application.properties
+          echo "${{ secrets.PROPERTIES }}" | tr -d '\r' > application.properties
+        shell: bash
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x back-end/reacton/gradlew
+
+      - name: Build with Gradle
+        run: cd back-end/reacton && ./gradlew clean build -x test --build-cache
+
+      - name: Check Build Artifact
+        run: ls -lh back-end/reacton/build/libs/ || (echo "Build artifact missing!" && exit 1)
+
+      - name: Docker Build and Push
+        run: |
+          sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          sudo docker pull ${{ secrets.DOCKER_USERNAME }}/reacton-back:latest || true
+          sudo docker build --cache-from ${{ secrets.DOCKER_USERNAME }}/reacton-back:latest \
+            -t ${{ secrets.DOCKER_USERNAME }}/reacton-back:latest back-end/reacton
+          sudo docker push ${{ secrets.DOCKER_USERNAME }}/reacton-back:latest
+
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ubuntu
+          key: ${{ secrets.PRIVATE_KEY }}
+          script: |
+            cd ~/app/back-end/reacton
+            rm -f .env
+            echo "DB_URL=jdbc:mysql://${{ secrets.DB_PRIVATE_IP }}:3306/reacton" > .env
+            echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> .env
+            echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+            echo "SPRING_JPA_HIBERNATE_DDL_AUTO=update" >> .env
+            echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> .env
+            sudo docker-compose pull
+            sudo docker-compose up -d --remove-orphans
+            rm -f .env
+            sudo docker image prune -f

--- a/back-end/reacton/Dockerfile
+++ b/back-end/reacton/Dockerfile
@@ -1,5 +1,6 @@
 FROM openjdk:17
+WORKDIR /app
 EXPOSE 8080
 ARG JAR_FILE=build/libs/reacton-0.0.1-SNAPSHOT.jar
-COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+COPY ${JAR_FILE} reacton.jar
+ENTRYPOINT ["java","-jar","reacton.jar"]


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#37 [BE] Docker + Github Actions 기반 CI/CD 구축

## 📝 작업 내용
back-end/reacton 프로젝트만 CI/CD를 수행합니다. 
우선 reacton 프로젝트에 대해 테스트해보고 추후에 reacton-classroom도 추가하겠습니다!

### 빌드 및 배포 
- build 후 docker hub에 이미지 업로드 
- EC2에서 docker 이미지 받아와서 컨테이너 실행

### 설정 값 관리
- 기본적인 설정은 secrets에 PROPERTIES로 관리
- 중요한 설정은 .env 파일로 작성
- docker-compose에서 해당 .env 파일에서 설정값 받아서 넣어줌
- .env 파일 EC2에서 삭제 -> 보안 