### PR TITLE
[BE] S3 자격증명 방식 변경 

### DIFF
--- a/back-end/reacton/build.gradle
+++ b/back-end/reacton/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'io.netty:netty-all:4.1.100.Final'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
-    implementation "software.amazon.awssdk:s3:2.13.0"
+    implementation "software.amazon.awssdk:s3:2.20.0"
 }
 
 tasks.named('test') {

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/professor/ProfessorService.java
@@ -18,7 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.net.URL;
 import java.util.*;
 
 @Slf4j
@@ -99,7 +98,10 @@ public class ProfessorService {
             return new BaseException(ProfessorErrorCode.USER_NOT_FOUND);
         });
 
-        URL profileImageUrl = s3Service.generatePresignedUrl(professor.getProfileImageS3Key(), PRESIGNED_URL_EXPIRATION_MINUTES);
+        String profileImageUrl = "";
+        if (isFileExists(professor)) {
+            profileImageUrl = s3Service.generatePresignedUrl(professor.getProfileImageS3Key(), PRESIGNED_URL_EXPIRATION_MINUTES).toString();
+        }
         return new ProfessorInfoResponse(professor.getName(), professor.getEmail(), String.valueOf(profileImageUrl));
     }
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/s3/S3Config.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/s3/S3Config.java
@@ -4,7 +4,7 @@ package com.softeer.reacton.global.s3;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -18,7 +18,7 @@ public class S3Config {
     public S3Client s3Client() {
         return S3Client.builder()
                 .region(Region.of(AWS_REGION))
-                .credentialsProvider(ProfileCredentialsProvider.create())
+                .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();
     }
 
@@ -26,7 +26,7 @@ public class S3Config {
     public S3Presigner s3Presigner() {
         return S3Presigner.builder()
                 .region(Region.of(AWS_REGION))
-                .credentialsProvider(ProfileCredentialsProvider.create())
+                .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#170 [BE] S3 자격증명 실패 

## 📝 작업 내용

### S3 자격증명 확인 및 AWS SDK 버전 업그레이드
- 기존에는 `ProfileCredentialsProvider`를 사용해서 `~/.aws/credentials`에 저장해둔 제 User 계정의 액세스 키로 S3에 접근했었습니다. 개발 환경에서는 사용이 가능하지만 운영 환경에서는 EC2에 부여한 Role 권한을 가지고 S3에 접근해야 해서 `DefaultCredentialsProvider`로 변경했습니다. 
-`DefaultCredentialsProvider`는 환경 변수, EC2 IAM Role, `~/.aws/credentials` 등을 자동으로 탐색해서 자격증명을 제공한다고 합니다. 각 실행 환경 별로 코드를 나누는 것보다 하나를 사용하는 것이 나을 것이라 판단하여 변경하였습니다. 
- `DefaultCredentialsProvider`는 기존 AWS SDK 2.13.0에서 사용이 불가하여 2.20.0로 업그레이드 했습니다. 

### 추가 버그 수정
- 회원 정보 조회 API 수행시 프로필 이미지가 없는 사용자의 경우에도 S3에 파일 Presigned-url을 요청해서 에러가 발생했습니다. 다른 API와 마찬가지로 DB에 파일 이름과 S3 key 값이 저장되어 있는 경우에만 presigned-url을 발급할 수 있도록 수정했습니다. 