### PR TITLE
[BE] 학생 메시지 전송 API 구현

### DIFF
--- a/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/controller/SseConnectionController.java
+++ b/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/controller/SseConnectionController.java
@@ -22,13 +22,13 @@ public class SseConnectionController {
     private final SseService sseService;
 
     @GetMapping(path = "/course/{courseId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<ServerSentEvent<MessageResponse>> subscribeCourse(@PathVariable String courseId) {
+    public Flux<ServerSentEvent<MessageResponse<?>>> subscribeCourse(@PathVariable String courseId) {
         log.debug("교수 SSE 연결을 요청합니다. : courseId = {}", courseId);
         return sseService.subscribeCourseMessages(courseId);
     }
 
     @GetMapping(path = "/student", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<ServerSentEvent<MessageResponse>> subscribeStudent(HttpServletRequest request) {
+    public Flux<ServerSentEvent<MessageResponse<?>>> subscribeStudent(HttpServletRequest request) {
         String studentId = (String) request.getAttribute("studentId");
         Long courseId = (Long) request.getAttribute("courseId");
 

--- a/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/controller/SseMessageController.java
+++ b/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/controller/SseMessageController.java
@@ -18,8 +18,8 @@ public class SseMessageController {
     private final SseService sseService;
 
     @PostMapping("/course/{courseId}")
-    public ResponseEntity<SuccessResponse> sendMessage(@PathVariable String courseId, @RequestBody MessageResponse message) {
-        log.debug("메시지 전송을 요청합니다. : courseId = {}", courseId);
+    public ResponseEntity<SuccessResponse> sendMessage(@PathVariable String courseId, @RequestBody MessageResponse<?> message) {
+        log.debug("메시지 전송을 요청합니다. : courseId = {}, type = {}", courseId, message.getMessageType());
         sseService.sendMessage(courseId, message);
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/dto/MessageResponse.java
+++ b/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/dto/MessageResponse.java
@@ -1,13 +1,17 @@
 package com.softeer.reacton_classroom.domain.sse.dto;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
-@JsonPropertyOrder({"type", "data"})
-public class MessageResponse {
-    private String type;
-    private String content;
+@JsonPropertyOrder({"messageType", "data"})
+@AllArgsConstructor
+@NoArgsConstructor
+public class MessageResponse<T> {
+    private String messageType;
+    private T data;
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseController.java
@@ -81,8 +81,8 @@ public class ProfessorCourseController {
             description = "courseId에 해당하는 수업의 상세 정보를 조회합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "조회에 성공했습니다."),
-                    @ApiResponse(responseCode = "404", description = "정보를 찾을 수 없습니다."),
-                    @ApiResponse(responseCode = "409", description = "해당 수업에 접근할 권한이 없습니다.")
+                    @ApiResponse(responseCode = "403", description = "해당 수업에 접근할 권한이 없습니다."),
+                    @ApiResponse(responseCode = "404", description = "정보를 찾을 수 없습니다.")
             }
     )
     public ResponseEntity<SuccessResponse<CourseDetailResponse>> getCourseDetail(

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -6,6 +6,7 @@ import com.softeer.reacton.domain.professor.ProfessorRepository;
 import com.softeer.reacton.domain.question.Question;
 import com.softeer.reacton.domain.question.QuestionRepository;
 import com.softeer.reacton.domain.request.Request;
+import com.softeer.reacton.domain.request.RequestConstants;
 import com.softeer.reacton.domain.request.RequestRepository;
 import com.softeer.reacton.domain.schedule.Schedule;
 import com.softeer.reacton.domain.schedule.ScheduleRepository;
@@ -61,6 +62,8 @@ public class ProfessorCourseService {
         Course course = Course.create(request, professor);
         List<Schedule> schedules = createSchedules(request, course);
         course.setSchedules(schedules);
+        List<Request> requests = createRequests(course);
+        course.setRequests(requests);
 
         return generateAccessCodeAndSave(course);
     }
@@ -259,6 +262,15 @@ public class ProfessorCourseService {
             schedules.add(schedule);
         }
         return schedules;
+    }
+
+    private List<Request> createRequests(Course course) {
+        List<Request> requests = new ArrayList<>();
+        for (String requestType : RequestConstants.REQUEST_TYPES) {
+            Request request = Request.create(requestType, course);
+            requests.add(request);
+        }
+        return requests;
     }
 
     private long generateAccessCodeAndSave(Course course) {

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseTransactionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseTransactionService.java
@@ -1,5 +1,7 @@
 package com.softeer.reacton.domain.course;
 
+import com.softeer.reacton.domain.request.Request;
+import com.softeer.reacton.domain.request.RequestRepository;
 import com.softeer.reacton.domain.schedule.Schedule;
 import com.softeer.reacton.domain.schedule.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,7 @@ public class ProfessorCourseTransactionService {
 
     private final CourseRepository courseRepository;
     private final ScheduleRepository scheduleRepository;
+    private final RequestRepository requestRepository;
 
     @Transactional
     public long saveCourse(Course course) {
@@ -22,6 +25,11 @@ public class ProfessorCourseTransactionService {
         for (Schedule schedule : course.getSchedules()) {
             schedule.setCourse(course);
             scheduleRepository.save(schedule);
+        }
+
+        for (Request request : course.getRequests()) {
+            request.setCourse(course);
+            requestRepository.save(request);
         }
 
         return course.getId();

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/Question.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/Question.java
@@ -4,6 +4,7 @@ import com.softeer.reacton.domain.course.Course;
 import com.softeer.reacton.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,10 +25,17 @@ public class Question extends BaseEntity {
     private String content;
 
     @Column(nullable = false, length = 20)
-    private String status;
+    private Boolean isComplete;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "course_id", nullable = false)
     private Course course; // 수업 정보 (외래 키)
 
+    @Builder
+    public Question(String studentId, String content, Course course) {
+        this.studentId = studentId;
+        this.content = content;
+        this.isComplete = false;
+        this.course = course;
+    }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/Question.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/Question.java
@@ -24,7 +24,7 @@ public class Question extends BaseEntity {
     @Column(nullable = false, length = 600)
     private String content;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false)
     private Boolean isComplete;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionController.java
@@ -75,6 +75,6 @@ public class StudentQuestionController {
 
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(SuccessResponse.of("성공적으로 등록했습니다.", response));
+                .body(SuccessResponse.of("질문을 성공적으로 등록했습니다.", response));
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionController.java
@@ -1,6 +1,6 @@
-package com.softeer.reacton.domain.classroom;
+package com.softeer.reacton.domain.question;
 
-import com.softeer.reacton.domain.classroom.dto.ClassroomQuestionResponse;
+import com.softeer.reacton.domain.question.dto.QuestionResponse;
 import com.softeer.reacton.global.dto.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -11,17 +11,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequiredArgsConstructor
+@RequestMapping("/students/questions")
 @Tag(name = "Student Classroom API", description = "학생 강의실 관련 API")
-public class StudentClassroomController {
+@RequiredArgsConstructor
+public class StudentQuestionController {
 
-    private final StudentClassroomService studentClassroomService;
+    private final StudentQuestionService studentQuestionService;
 
-    @GetMapping("/{accessCode}/summary")
+    @GetMapping
     @Operation(
             summary = "학생 질문 목록 조회",
             description = "학생이 이전에 질문했던 목록을 조회합니다.",
@@ -32,13 +34,13 @@ public class StudentClassroomController {
                     @ApiResponse(responseCode = "500", description = "서버와의 연결에 실패했습니다.")
             }
     )
-    public ResponseEntity<SuccessResponse<ClassroomQuestionResponse>> getQuestions(HttpServletRequest request) {
+    public ResponseEntity<SuccessResponse<QuestionResponse>> getQuestions(HttpServletRequest request) {
         log.debug("학생 사용자가 이전에 질문했던 목록을 요청합니다.");
 
         String studentId = (String) request.getAttribute("studentId");
         Long courseId = (Long) request.getAttribute("courseId");
 
-        ClassroomQuestionResponse response = studentClassroomService.getQuestionsByStudentId(studentId, courseId);
+        QuestionResponse response = studentQuestionService.getQuestionsByStudentId(studentId, courseId);
 
         log.info("질문 목록을 성공적으로 조회했습니다.");
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequestMapping("/students/questions")
-@Tag(name = "Student Classroom API", description = "학생 강의실 관련 API")
+@Tag(name = "Student Questions API", description = "학생 질문 관련 API")
 @RequiredArgsConstructor
 public class StudentQuestionController {
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -61,7 +62,7 @@ public class StudentQuestionController {
             }
     )
     public ResponseEntity<SuccessResponse<CourseQuestionResponse>> sendQuestion(
-            @RequestBody QuestionSendRequest questionSendRequest,
+            @Valid @RequestBody QuestionSendRequest questionSendRequest,
             HttpServletRequest request) {
         log.debug("학생 사용자가 질문 등록 및 전송을 요청합니다.");
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionController.java
@@ -1,6 +1,8 @@
 package com.softeer.reacton.domain.question;
 
-import com.softeer.reacton.domain.question.dto.QuestionResponse;
+import com.softeer.reacton.domain.course.dto.CourseQuestionResponse;
+import com.softeer.reacton.domain.question.dto.QuestionAllResponse;
+import com.softeer.reacton.domain.question.dto.QuestionSendRequest;
 import com.softeer.reacton.global.dto.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -10,9 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -34,18 +34,47 @@ public class StudentQuestionController {
                     @ApiResponse(responseCode = "500", description = "서버와의 연결에 실패했습니다.")
             }
     )
-    public ResponseEntity<SuccessResponse<QuestionResponse>> getQuestions(HttpServletRequest request) {
+    public ResponseEntity<SuccessResponse<QuestionAllResponse>> getQuestions(HttpServletRequest request) {
         log.debug("학생 사용자가 이전에 질문했던 목록을 요청합니다.");
 
         String studentId = (String) request.getAttribute("studentId");
         Long courseId = (Long) request.getAttribute("courseId");
 
-        QuestionResponse response = studentQuestionService.getQuestionsByStudentId(studentId, courseId);
+        QuestionAllResponse response = studentQuestionService.getQuestionsByStudentId(studentId, courseId);
 
         log.info("질문 목록을 성공적으로 조회했습니다.");
 
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.of("성공적으로 조회했습니다.", response));
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "학생 질문 전송",
+            description = "학생이 교수에게 질문을 전송합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공적으로 전송했습니다."),
+                    @ApiResponse(responseCode = "404", description = "수업을 찾을 수 없습니다."),
+                    @ApiResponse(responseCode = "409", description = "아직 수업이 시작되지 않았습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버와의 연결에 실패했습니다.")
+            }
+    )
+    public ResponseEntity<SuccessResponse<CourseQuestionResponse>> sendQuestion(
+            @RequestBody QuestionSendRequest questionSendRequest,
+            HttpServletRequest request) {
+        log.debug("학생 사용자가 질문 등록 및 전송을 요청합니다.");
+
+        String studentId = (String) request.getAttribute("studentId");
+        Long courseId = (Long) request.getAttribute("courseId");
+        String content = questionSendRequest.getContent();
+
+        CourseQuestionResponse response = studentQuestionService.sendQuestion(studentId, courseId, content);
+
+        log.info("질문을 성공적으로 등록했습니다.");
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.of("성공적으로 등록했습니다.", response));
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionController.java
@@ -68,9 +68,8 @@ public class StudentQuestionController {
 
         String studentId = (String) request.getAttribute("studentId");
         Long courseId = (Long) request.getAttribute("courseId");
-        String content = questionSendRequest.getContent();
 
-        CourseQuestionResponse response = studentQuestionService.sendQuestion(studentId, courseId, content);
+        CourseQuestionResponse response = studentQuestionService.sendQuestion(studentId, courseId, questionSendRequest);
 
         log.info("질문을 성공적으로 등록했습니다.");
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionService.java
@@ -3,9 +3,11 @@ package com.softeer.reacton.domain.question;
 import com.softeer.reacton.domain.course.Course;
 import com.softeer.reacton.domain.course.CourseRepository;
 import com.softeer.reacton.domain.course.dto.CourseQuestionResponse;
-import com.softeer.reacton.domain.question.dto.QuestionResponse;
+import com.softeer.reacton.domain.question.dto.QuestionAllResponse;
 import com.softeer.reacton.global.exception.BaseException;
 import com.softeer.reacton.global.exception.code.CourseErrorCode;
+import com.softeer.reacton.global.sse.SseMessageSender;
+import com.softeer.reacton.global.sse.dto.SseMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,15 +23,47 @@ public class StudentQuestionService {
 
     private final QuestionRepository questionRepository;
     private final CourseRepository courseRepository;
+    private final SseMessageSender sseMessageSender;
 
     @Transactional(readOnly = true)
-    public QuestionResponse getQuestionsByStudentId(String studentId, Long courseId) {
+    public QuestionAllResponse getQuestionsByStudentId(String studentId, Long courseId) {
         log.debug("이전에 질문했던 목록을 조회합니다. : studentId = {}, courseId = {}", studentId, courseId);
 
         Course course = getCourse(courseId);
         List<CourseQuestionResponse> questions = findQuestions(studentId, course);
 
-        return QuestionResponse.of(questions);
+        return QuestionAllResponse.of(questions);
+    }
+
+    @Transactional
+    public CourseQuestionResponse sendQuestion(String studentId, Long courseId, String content) {
+        log.debug("질문 처리를 시작합니다. : content = {}", content);
+
+        Course course = getCourse(courseId);
+        checkIfOpen(course);
+
+        Question question = Question.builder()
+                .studentId(studentId)
+                .content(content)
+                .course(course)
+                .build();
+
+        log.debug("질문을 저장합니다.");
+        System.out.println("question.isComplete: " + question.getIsComplete());
+        Question savedQuestion = questionRepository.save(question);
+
+        CourseQuestionResponse questionDto = new CourseQuestionResponse(
+                savedQuestion.getId(),
+                savedQuestion.getCreatedAt(),
+                savedQuestion.getContent()
+        );
+
+        log.debug("SSE 서버에 질문 전송을 요청합니다.");
+        SseMessage<CourseQuestionResponse> sseMessage = new SseMessage<>("QUESTION", questionDto);
+        sseMessageSender.sendMessageToProfessor(courseId, sseMessage);
+
+        log.debug("질문 처리가 완료되었습니다.");
+        return questionDto;
     }
 
     private Course getCourse(Long courseId) {
@@ -47,5 +81,11 @@ public class StudentQuestionService {
                         question.getContent()
                 ))
                 .collect(Collectors.toList());
+    }
+
+    private void checkIfOpen(Course course) {
+        if (!course.isActive()) {
+            throw new BaseException(CourseErrorCode.COURSE_NOT_ACTIVE);
+        }
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionService.java
@@ -49,7 +49,6 @@ public class StudentQuestionService {
                 .build();
 
         log.debug("질문을 저장합니다.");
-        System.out.println("question.isComplete: " + question.getIsComplete());
         Question savedQuestion = questionRepository.save(question);
 
         CourseQuestionResponse questionDto = new CourseQuestionResponse(

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionService.java
@@ -1,11 +1,9 @@
-package com.softeer.reacton.domain.classroom;
+package com.softeer.reacton.domain.question;
 
-import com.softeer.reacton.domain.classroom.dto.ClassroomQuestionResponse;
 import com.softeer.reacton.domain.course.Course;
 import com.softeer.reacton.domain.course.CourseRepository;
 import com.softeer.reacton.domain.course.dto.CourseQuestionResponse;
-import com.softeer.reacton.domain.question.Question;
-import com.softeer.reacton.domain.question.QuestionRepository;
+import com.softeer.reacton.domain.question.dto.QuestionResponse;
 import com.softeer.reacton.global.exception.BaseException;
 import com.softeer.reacton.global.exception.code.CourseErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -19,19 +17,19 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class StudentClassroomService {
+public class StudentQuestionService {
 
     private final QuestionRepository questionRepository;
     private final CourseRepository courseRepository;
 
     @Transactional(readOnly = true)
-    public ClassroomQuestionResponse getQuestionsByStudentId(String studentId, Long courseId) {
+    public QuestionResponse getQuestionsByStudentId(String studentId, Long courseId) {
         log.debug("이전에 질문했던 목록을 조회합니다. : studentId = {}, courseId = {}", studentId, courseId);
 
         Course course = getCourse(courseId);
         List<CourseQuestionResponse> questions = findQuestions(studentId, course);
 
-        return ClassroomQuestionResponse.of(questions);
+        return QuestionResponse.of(questions);
     }
 
     private Course getCourse(Long courseId) {

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionService.java
@@ -4,6 +4,7 @@ import com.softeer.reacton.domain.course.Course;
 import com.softeer.reacton.domain.course.CourseRepository;
 import com.softeer.reacton.domain.course.dto.CourseQuestionResponse;
 import com.softeer.reacton.domain.question.dto.QuestionAllResponse;
+import com.softeer.reacton.domain.question.dto.QuestionSendRequest;
 import com.softeer.reacton.global.exception.BaseException;
 import com.softeer.reacton.global.exception.code.CourseErrorCode;
 import com.softeer.reacton.global.sse.SseMessageSender;
@@ -36,7 +37,8 @@ public class StudentQuestionService {
     }
 
     @Transactional
-    public CourseQuestionResponse sendQuestion(String studentId, Long courseId, String content) {
+    public CourseQuestionResponse sendQuestion(String studentId, Long courseId, QuestionSendRequest questionSendRequest) {
+        String content = questionSendRequest.getContent();
         log.debug("질문 처리를 시작합니다. : content = {}", content);
 
         Course course = getCourse(courseId);
@@ -51,18 +53,18 @@ public class StudentQuestionService {
         log.debug("질문을 저장합니다.");
         Question savedQuestion = questionRepository.save(question);
 
-        CourseQuestionResponse questionDto = new CourseQuestionResponse(
+        CourseQuestionResponse courseQuestionResponse = new CourseQuestionResponse(
                 savedQuestion.getId(),
                 savedQuestion.getCreatedAt(),
                 savedQuestion.getContent()
         );
 
         log.debug("SSE 서버에 질문 전송을 요청합니다.");
-        SseMessage<CourseQuestionResponse> sseMessage = new SseMessage<>("QUESTION", questionDto);
+        SseMessage<CourseQuestionResponse> sseMessage = new SseMessage<>("QUESTION", courseQuestionResponse);
         sseMessageSender.sendMessageToProfessor(courseId, sseMessage);
 
         log.debug("질문 처리가 완료되었습니다.");
-        return questionDto;
+        return courseQuestionResponse;
     }
 
     private Course getCourse(Long courseId) {

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/dto/QuestionAllResponse.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/dto/QuestionAllResponse.java
@@ -8,11 +8,11 @@ import java.util.List;
 
 @Getter
 @Builder
-public class QuestionResponse {
+public class QuestionAllResponse {
     List<CourseQuestionResponse> questions;
 
-    public static QuestionResponse of(List<CourseQuestionResponse> questions) {
-        return QuestionResponse.builder()
+    public static QuestionAllResponse of(List<CourseQuestionResponse> questions) {
+        return QuestionAllResponse.builder()
                 .questions(questions)
                 .build();
     }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/dto/QuestionResponse.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/dto/QuestionResponse.java
@@ -1,4 +1,4 @@
-package com.softeer.reacton.domain.classroom.dto;
+package com.softeer.reacton.domain.question.dto;
 
 import com.softeer.reacton.domain.course.dto.CourseQuestionResponse;
 import lombok.Builder;
@@ -8,11 +8,11 @@ import java.util.List;
 
 @Getter
 @Builder
-public class ClassroomQuestionResponse {
+public class QuestionResponse {
     List<CourseQuestionResponse> questions;
 
-    public static ClassroomQuestionResponse of(List<CourseQuestionResponse> questions) {
-        return ClassroomQuestionResponse.builder()
+    public static QuestionResponse of(List<CourseQuestionResponse> questions) {
+        return QuestionResponse.builder()
                 .questions(questions)
                 .build();
     }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/dto/QuestionSendRequest.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/dto/QuestionSendRequest.java
@@ -1,8 +1,14 @@
 package com.softeer.reacton.domain.question.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class QuestionSendRequest {
-    private String content;
+    @NotBlank(message = "질문 내용이 비어 있습니다.")
+    @Size(max = 200, message = "질문은 200자를 넘길 수 없습니다.")
+    private final String content;
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/dto/QuestionSendRequest.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/dto/QuestionSendRequest.java
@@ -1,0 +1,8 @@
+package com.softeer.reacton.domain.question.dto;
+
+import lombok.Getter;
+
+@Getter
+public class QuestionSendRequest {
+    private String content;
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/StudentReactionController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/StudentReactionController.java
@@ -1,7 +1,6 @@
 package com.softeer.reacton.domain.reaction;
 
 import com.softeer.reacton.domain.reaction.dto.ReactionSendRequest;
-import com.softeer.reacton.global.dto.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/StudentReactionController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/StudentReactionController.java
@@ -42,9 +42,8 @@ public class StudentReactionController {
         log.debug("학생 사용자가 반응 등록 및 전송을 요청합니다.");
 
         Long courseId = (Long) request.getAttribute("courseId");
-        String content = reactionSendRequest.getContent();
 
-        studentReactionService.sendReaction(courseId, content);
+        studentReactionService.sendReaction(courseId, reactionSendRequest);
 
         log.info("반응을 성공적으로 등록했습니다.");
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/StudentReactionController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/StudentReactionController.java
@@ -36,7 +36,7 @@ public class StudentReactionController {
                     @ApiResponse(responseCode = "500", description = "서버와의 연결에 실패했습니다.")
             }
     )
-    public ResponseEntity<SuccessResponse<Void>> sendReaction(
+    public ResponseEntity<Void> sendReaction(
             @Valid @RequestBody ReactionSendRequest reactionSendRequest,
                     HttpServletRequest request) {
         log.debug("학생 사용자가 반응 등록 및 전송을 요청합니다.");
@@ -48,7 +48,7 @@ public class StudentReactionController {
         log.info("반응을 성공적으로 등록했습니다.");
 
         return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(SuccessResponse.of("반응을 성공적으로 등록했습니다."));
+                .status(HttpStatus.NO_CONTENT)
+                .build();
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/StudentReactionController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/StudentReactionController.java
@@ -1,0 +1,55 @@
+package com.softeer.reacton.domain.reaction;
+
+import com.softeer.reacton.domain.reaction.dto.ReactionSendRequest;
+import com.softeer.reacton.global.dto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/students/reactions")
+@Tag(name = "Student Reaction API", description = "학생 반응 관련 API")
+@RequiredArgsConstructor
+public class StudentReactionController {
+
+    private final StudentReactionService studentReactionService;
+
+    @PostMapping
+    @Operation(
+            summary = "학생 반응 전송",
+            description = "학생이 교수에게 반응을 전송합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공적으로 전송했습니다."),
+                    @ApiResponse(responseCode = "404", description = "수업을 찾을 수 없습니다."),
+                    @ApiResponse(responseCode = "409", description = "아직 수업이 시작되지 않았습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버와의 연결에 실패했습니다.")
+            }
+    )
+    public ResponseEntity<SuccessResponse<Void>> sendReaction(
+            @Valid @RequestBody ReactionSendRequest reactionSendRequest,
+                    HttpServletRequest request) {
+        log.debug("학생 사용자가 반응 등록 및 전송을 요청합니다.");
+
+        Long courseId = (Long) request.getAttribute("courseId");
+        String content = reactionSendRequest.getContent();
+
+        studentReactionService.sendReaction(courseId, content);
+
+        log.info("반응을 성공적으로 등록했습니다.");
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.of("반응을 성공적으로 등록했습니다."));
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/StudentReactionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/StudentReactionService.java
@@ -2,6 +2,7 @@ package com.softeer.reacton.domain.reaction;
 
 import com.softeer.reacton.domain.course.Course;
 import com.softeer.reacton.domain.course.CourseRepository;
+import com.softeer.reacton.domain.reaction.dto.ReactionSendRequest;
 import com.softeer.reacton.domain.reaction.dto.ReactionSseRequest;
 import com.softeer.reacton.global.exception.BaseException;
 import com.softeer.reacton.global.exception.code.CourseErrorCode;
@@ -19,16 +20,17 @@ public class StudentReactionService {
     private final CourseRepository courseRepository;
     private final SseMessageSender sseMessageSender;
 
-    public void sendReaction(Long courseId, String content) {
+    public void sendReaction(Long courseId, ReactionSendRequest reactionSendRequest) {
+        String content = reactionSendRequest.getContent();
         log.debug("반응 처리를 시작합니다. : content = {}", content);
 
         Course course = getCourse(courseId);
         checkIfOpen(course);
 
-        ReactionSseRequest reactionSseDto = new ReactionSseRequest(content);
+        ReactionSseRequest reactionSseRequest = new ReactionSseRequest(content);
 
         log.debug("SSE 서버에 반응 전송을 요청합니다.");
-        SseMessage<ReactionSseRequest> sseMessage = new SseMessage<>("REACTION", reactionSseDto);
+        SseMessage<ReactionSseRequest> sseMessage = new SseMessage<>("REACTION", reactionSseRequest);
         sseMessageSender.sendMessageToProfessor(courseId, sseMessage);
     }
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/StudentReactionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/StudentReactionService.java
@@ -1,0 +1,45 @@
+package com.softeer.reacton.domain.reaction;
+
+import com.softeer.reacton.domain.course.Course;
+import com.softeer.reacton.domain.course.CourseRepository;
+import com.softeer.reacton.domain.reaction.dto.ReactionSseRequest;
+import com.softeer.reacton.global.exception.BaseException;
+import com.softeer.reacton.global.exception.code.CourseErrorCode;
+import com.softeer.reacton.global.sse.SseMessageSender;
+import com.softeer.reacton.global.sse.dto.SseMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StudentReactionService {
+
+    private final CourseRepository courseRepository;
+    private final SseMessageSender sseMessageSender;
+
+    public void sendReaction(Long courseId, String content) {
+        log.debug("반응 처리를 시작합니다. : content = {}", content);
+
+        Course course = getCourse(courseId);
+        checkIfOpen(course);
+
+        ReactionSseRequest reactionSseDto = new ReactionSseRequest(content);
+
+        log.debug("SSE 서버에 반응 전송을 요청합니다.");
+        SseMessage<ReactionSseRequest> sseMessage = new SseMessage<>("REACTION", reactionSseDto);
+        sseMessageSender.sendMessageToProfessor(courseId, sseMessage);
+    }
+
+    private Course getCourse(Long courseId) {
+        return courseRepository.findById(courseId)
+                .orElseThrow(() -> new BaseException(CourseErrorCode.COURSE_NOT_FOUND));
+    }
+
+    private void checkIfOpen(Course course) {
+        if (!course.isActive()) {
+            throw new BaseException(CourseErrorCode.COURSE_NOT_ACTIVE);
+        }
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/dto/ReactionSendRequest.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/dto/ReactionSendRequest.java
@@ -1,0 +1,14 @@
+package com.softeer.reacton.domain.reaction.dto;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class ReactionSendRequest {
+
+    @Pattern(
+            regexp = "^(OKAY|CLAP|THUMBS_UP|HEART_EYES|CRYING|SURPRISED)$",
+            message = "반응에 들어갈 값이 잘못되었습니다."
+    )
+    private String content;
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/dto/ReactionSendRequest.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/dto/ReactionSendRequest.java
@@ -1,14 +1,16 @@
 package com.softeer.reacton.domain.reaction.dto;
 
 import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class ReactionSendRequest {
 
     @Pattern(
             regexp = "^(OKAY|CLAP|THUMBS_UP|HEART_EYES|CRYING|SURPRISED)$",
             message = "반응에 들어갈 값이 잘못되었습니다."
     )
-    private String content;
+    private final String content;
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/dto/ReactionSseRequest.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/dto/ReactionSseRequest.java
@@ -1,0 +1,10 @@
+package com.softeer.reacton.domain.reaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReactionSseRequest {
+    private String type;
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/Request.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/Request.java
@@ -2,9 +2,7 @@ package com.softeer.reacton.domain.request;
 
 import com.softeer.reacton.domain.course.Course;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,7 +20,21 @@ public class Request {
     @Column(nullable = false, columnDefinition = "INT DEFAULT 0")
     private int count;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "course_id", nullable = false)
     private Course course;
+
+    @Builder
+    public Request(String type, Course course) {
+        this.type = type;
+        this.count = 0;
+        this.course = course;
+    }
+
+    public static Request create(String type, Course course) {
+        return Request.builder()
+                .type(type)
+                .course(course).build();
+    }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/RequestConstants.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/RequestConstants.java
@@ -1,0 +1,13 @@
+package com.softeer.reacton.domain.request;
+
+import java.util.List;
+
+public class RequestConstants {
+    public static final List<String> REQUEST_TYPES = List.of(
+            "SCREEN_ISSUE",
+            "HAVE_QUESTION",
+            "DIFFICULT",
+            "SOUND_ISSUE",
+            "TOO_FAST"
+    );
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/RequestController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/RequestController.java
@@ -1,9 +1,0 @@
-package com.softeer.reacton.domain.request;
-
-import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.RestController;
-
-@RestController
-@Tag(name = "Request API", description = "요청 관련 API")
-public class RequestController {
-}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/RequestRepository.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/RequestRepository.java
@@ -2,7 +2,20 @@ package com.softeer.reacton.domain.request;
 
 import com.softeer.reacton.domain.course.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface RequestRepository extends JpaRepository<Request, Long> {
     void deleteAllByCourse(Course course);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Request r " +
+            "SET r.count = r.count + 1 " +
+            "WHERE r.course = :course " +
+            "  AND r.type = :type")
+    int incrementCount(@Param("course") Course course,
+                       @Param("type") String type);
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/RequestRepository.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/RequestRepository.java
@@ -5,13 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface RequestRepository extends JpaRepository<Request, Long> {
     void deleteAllByCourse(Course course);
 
     @Modifying
-    @Transactional
     @Query("UPDATE Request r " +
             "SET r.count = r.count + 1 " +
             "WHERE r.course = :course " +

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestController.java
@@ -42,9 +42,8 @@ public class StudentRequestController {
         log.debug("학생 사용자가 요청 등록 및 전송을 요청합니다.");
 
         Long courseId = (Long) request.getAttribute("courseId");
-        String content = requestSendRequest.getContent();
 
-        studentRequestService.sendRequest(courseId, content);
+        studentRequestService.sendRequest(courseId, requestSendRequest);
 
         log.info("요청을 성공적으로 등록했습니다.");
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestController.java
@@ -36,7 +36,7 @@ public class StudentRequestController {
                     @ApiResponse(responseCode = "500", description = "서버와의 연결에 실패했습니다.")
             }
     )
-    public ResponseEntity<SuccessResponse<Void>> sendRequest(
+    public ResponseEntity<Void> sendRequest(
             @Valid @RequestBody RequestSendRequest requestSendRequest,
             HttpServletRequest request) {
         log.debug("학생 사용자가 요청 등록 및 전송을 요청합니다.");
@@ -48,7 +48,7 @@ public class StudentRequestController {
         log.info("요청을 성공적으로 등록했습니다.");
 
         return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(SuccessResponse.of("요청을 성공적으로 등록했습니다."));
+                .status(HttpStatus.NO_CONTENT)
+                .build();
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestController.java
@@ -49,6 +49,6 @@ public class StudentRequestController {
 
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(SuccessResponse.of("요청을 성공적으로 동록했습니다."));
+                .body(SuccessResponse.of("요청을 성공적으로 등록했습니다."));
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestController.java
@@ -41,7 +41,6 @@ public class StudentRequestController {
             HttpServletRequest request) {
         log.debug("학생 사용자가 요청 등록 및 전송을 요청합니다.");
 
-        String studentId = (String) request.getAttribute("studentId");
         Long courseId = (Long) request.getAttribute("courseId");
         String content = requestSendRequest.getContent();
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestController.java
@@ -1,7 +1,6 @@
 package com.softeer.reacton.domain.request;
 
 import com.softeer.reacton.domain.request.dto.RequestSendRequest;
-import com.softeer.reacton.global.dto.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestController.java
@@ -1,0 +1,56 @@
+package com.softeer.reacton.domain.request;
+
+import com.softeer.reacton.domain.request.dto.RequestSendRequest;
+import com.softeer.reacton.global.dto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/students/requests")
+@Tag(name = "Student Request API", description = "학생 요청 관련 API")
+@RequiredArgsConstructor
+public class StudentRequestController {
+
+    private final StudentRequestService studentRequestService;
+
+    @PostMapping
+    @Operation(
+            summary = "학생 요청 전송",
+            description = "학생이 교수에게 요청을 전송합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공적으로 전송했습니다."),
+                    @ApiResponse(responseCode = "404", description = "수업을 찾을 수 없습니다."),
+                    @ApiResponse(responseCode = "409", description = "아직 수업이 시작되지 않았습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버와의 연결에 실패했습니다.")
+            }
+    )
+    public ResponseEntity<SuccessResponse<Void>> sendRequest(
+            @Valid @RequestBody RequestSendRequest requestSendRequest,
+            HttpServletRequest request) {
+        log.debug("학생 사용자가 요청 등록 및 전송을 요청합니다.");
+
+        String studentId = (String) request.getAttribute("studentId");
+        Long courseId = (Long) request.getAttribute("courseId");
+        String content = requestSendRequest.getContent();
+
+        studentRequestService.sendRequest(courseId, content);
+
+        log.info("요청을 성공적으로 등록했습니다.");
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.of("요청을 성공적으로 동록했습니다."));
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestService.java
@@ -1,0 +1,56 @@
+package com.softeer.reacton.domain.request;
+
+import com.softeer.reacton.domain.course.Course;
+import com.softeer.reacton.domain.course.CourseRepository;
+import com.softeer.reacton.domain.request.dto.RequestSseRequest;
+import com.softeer.reacton.global.exception.BaseException;
+import com.softeer.reacton.global.exception.code.CourseErrorCode;
+import com.softeer.reacton.global.exception.code.RequestErrorCode;
+import com.softeer.reacton.global.sse.SseMessageSender;
+import com.softeer.reacton.global.sse.dto.SseMessage;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StudentRequestService {
+
+    private final CourseRepository courseRepository;
+    private final RequestRepository requestRepository;
+    private final SseMessageSender sseMessageSender;
+
+    @Transactional
+    public void sendRequest(Long courseId, String content) {
+        log.debug("요청 처리를 시작합니다. : content = {}", content);
+
+        Course course = getCourse(courseId);
+        checkIfOpen(course);
+
+        log.debug("요청을 저장합니다.");
+        int updatedRows = requestRepository.incrementCount(courseId, content);
+        if (updatedRows == 0) {
+            log.debug("요청 데이터를 처리하는 과정에서 발생한 에러입니다. : Request does not exist.");
+            throw new BaseException(RequestErrorCode.REQUEST_NOT_FOUND);
+        }
+
+        RequestSseRequest requestSseDto = new RequestSseRequest(content);
+
+        log.debug("SSE 서버에 요청 전송을 요청합니다.");
+        SseMessage<RequestSseRequest> sseMessage = new SseMessage<>("REQUEST", requestSseDto);
+        sseMessageSender.sendMessageToProfessor(courseId, sseMessage);
+    }
+
+    private Course getCourse(Long courseId) {
+        return courseRepository.findById(courseId)
+                .orElseThrow(() -> new BaseException(CourseErrorCode.COURSE_NOT_FOUND));
+    }
+
+    private void checkIfOpen(Course course) {
+        if (!course.isActive()) {
+            throw new BaseException(CourseErrorCode.COURSE_NOT_ACTIVE);
+        }
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestService.java
@@ -2,6 +2,7 @@ package com.softeer.reacton.domain.request;
 
 import com.softeer.reacton.domain.course.Course;
 import com.softeer.reacton.domain.course.CourseRepository;
+import com.softeer.reacton.domain.request.dto.RequestSendRequest;
 import com.softeer.reacton.domain.request.dto.RequestSseRequest;
 import com.softeer.reacton.global.exception.BaseException;
 import com.softeer.reacton.global.exception.code.CourseErrorCode;
@@ -23,7 +24,8 @@ public class StudentRequestService {
     private final SseMessageSender sseMessageSender;
 
     @Transactional
-    public void sendRequest(Long courseId, String content) {
+    public void sendRequest(Long courseId, RequestSendRequest requestSendRequest) {
+        String content = requestSendRequest.getContent();
         log.debug("요청 처리를 시작합니다. : content = {}", content);
 
         Course course = getCourse(courseId);
@@ -36,10 +38,10 @@ public class StudentRequestService {
             throw new BaseException(RequestErrorCode.REQUEST_NOT_FOUND);
         }
 
-        RequestSseRequest requestSseDto = new RequestSseRequest(content);
+        RequestSseRequest requestSseRequest = new RequestSseRequest(content);
 
         log.debug("SSE 서버에 요청 전송을 요청합니다.");
-        SseMessage<RequestSseRequest> sseMessage = new SseMessage<>("REQUEST", requestSseDto);
+        SseMessage<RequestSseRequest> sseMessage = new SseMessage<>("REQUEST", requestSseRequest);
         sseMessageSender.sendMessageToProfessor(courseId, sseMessage);
     }
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestService.java
@@ -30,7 +30,7 @@ public class StudentRequestService {
         checkIfOpen(course);
 
         log.debug("요청을 저장합니다.");
-        int updatedRows = requestRepository.incrementCount(courseId, content);
+        int updatedRows = requestRepository.incrementCount(course, content);
         if (updatedRows == 0) {
             log.debug("요청 데이터를 처리하는 과정에서 발생한 에러입니다. : Request does not exist.");
             throw new BaseException(RequestErrorCode.REQUEST_NOT_FOUND);

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/dto/RequestSendRequest.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/dto/RequestSendRequest.java
@@ -1,0 +1,14 @@
+package com.softeer.reacton.domain.request.dto;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class RequestSendRequest {
+
+    @Pattern(
+            regexp = "^(SCREEN_ISSUE|HAVE_QUESTION|DIFFICULT|SOUND_ISSUE|TOO_FAST)$",
+            message = "요청에 들어갈 값이 잘못되었습니다."
+    )
+    private String content;
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/dto/RequestSendRequest.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/dto/RequestSendRequest.java
@@ -1,14 +1,16 @@
 package com.softeer.reacton.domain.request.dto;
 
 import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class RequestSendRequest {
 
     @Pattern(
             regexp = "^(SCREEN_ISSUE|HAVE_QUESTION|DIFFICULT|SOUND_ISSUE|TOO_FAST)$",
             message = "요청에 들어갈 값이 잘못되었습니다."
     )
-    private String content;
+    private final String content;
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/dto/RequestSseRequest.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/dto/RequestSseRequest.java
@@ -1,0 +1,10 @@
+package com.softeer.reacton.domain.request.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RequestSseRequest {
+    private String type;
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/dto/SuccessResponse.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/dto/SuccessResponse.java
@@ -1,10 +1,10 @@
 package com.softeer.reacton.global.dto;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.softeer.reacton.domain.classroom.dto.ClassroomQuestionResponse;
 import com.softeer.reacton.domain.course.dto.CourseAllResponse;
 import com.softeer.reacton.domain.course.dto.CourseDetailResponse;
 import com.softeer.reacton.domain.course.dto.CourseSummaryResponse;
+import com.softeer.reacton.domain.question.dto.QuestionResponse;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -52,8 +52,8 @@ public class SuccessResponse<T> {
                 .build();
     }
 
-    public static SuccessResponse<ClassroomQuestionResponse> of(String message, ClassroomQuestionResponse data) {
-        return SuccessResponse.<ClassroomQuestionResponse>builder()
+    public static SuccessResponse<QuestionResponse> of(String message, QuestionResponse data) {
+        return SuccessResponse.<QuestionResponse>builder()
                 .message(message)
                 .data(data)
                 .build();

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/dto/SuccessResponse.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/dto/SuccessResponse.java
@@ -25,6 +25,11 @@ public class SuccessResponse<T> {
         this.data = data;
     }
 
+    public static SuccessResponse<Void> of(String message) {
+        return SuccessResponse.<Void>builder()
+                .message(message).build();
+    }
+
     public static SuccessResponse<Map<String, String>> of(String message, Map<String, String> data) {
         return SuccessResponse.<Map<String, String>>builder()
                 .message(message)

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/dto/SuccessResponse.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/dto/SuccessResponse.java
@@ -3,8 +3,9 @@ package com.softeer.reacton.global.dto;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.softeer.reacton.domain.course.dto.CourseAllResponse;
 import com.softeer.reacton.domain.course.dto.CourseDetailResponse;
+import com.softeer.reacton.domain.course.dto.CourseQuestionResponse;
 import com.softeer.reacton.domain.course.dto.CourseSummaryResponse;
-import com.softeer.reacton.domain.question.dto.QuestionResponse;
+import com.softeer.reacton.domain.question.dto.QuestionAllResponse;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -44,6 +45,13 @@ public class SuccessResponse<T> {
                 .data(data)
                 .build();
     }
+
+    public static SuccessResponse<CourseQuestionResponse> of(String message, CourseQuestionResponse data) {
+        return SuccessResponse.<CourseQuestionResponse>builder()
+                .message(message)
+                .data(data)
+                .build();
+    }
   
     public static SuccessResponse<CourseAllResponse> of(String message, CourseAllResponse data) {
         return SuccessResponse.<CourseAllResponse>builder()
@@ -52,8 +60,8 @@ public class SuccessResponse<T> {
                 .build();
     }
 
-    public static SuccessResponse<QuestionResponse> of(String message, QuestionResponse data) {
-        return SuccessResponse.<QuestionResponse>builder()
+    public static SuccessResponse<QuestionAllResponse> of(String message, QuestionAllResponse data) {
+        return SuccessResponse.<QuestionAllResponse>builder()
                 .message(message)
                 .data(data)
                 .build();

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/dto/SuccessResponse.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/dto/SuccessResponse.java
@@ -25,11 +25,6 @@ public class SuccessResponse<T> {
         this.data = data;
     }
 
-    public static SuccessResponse<Void> of(String message) {
-        return SuccessResponse.<Void>builder()
-                .message(message).build();
-    }
-
     public static SuccessResponse<Map<String, String>> of(String message, Map<String, String> data) {
         return SuccessResponse.<Map<String, String>>builder()
                 .message(message)

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/RequestErrorCode.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/RequestErrorCode.java
@@ -1,0 +1,19 @@
+package com.softeer.reacton.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum RequestErrorCode implements ErrorCode {
+    REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "요청 데이터를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return name();
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/SseErrorCode.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/SseErrorCode.java
@@ -1,0 +1,19 @@
+package com.softeer.reacton.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SseErrorCode implements ErrorCode {
+    MESSAGE_SEND_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "메시지 전송에 실패했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return name();
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/jwt/JwtAuthenticationFilter.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/jwt/JwtAuthenticationFilter.java
@@ -40,22 +40,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     );
 
     private static final List<String> STUDENT_ACCESS_URLS = List.of(
-            "/students/classroom",
-            "/students/question",
-            "/students/request",
-            "/students/reaction"
+            "/students/questions",
+            "/students/requests",
+            "/students/reactions"
     );
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
-        log.debug("JWT 토큰 관련 필터 작업을 수행합니다.");
-
         String requestUri = request.getRequestURI();
-        log.debug("URL : " + requestUri);
-        if (isWhiteListed("/v3/api-docs/swagger-config")) log.debug("/v3/api-docs 있음");
+        log.debug("JWT 토큰 관련 필터 작업을 수행합니다. : requestUri = {}", requestUri);
+
         if (isWhiteListed(requestUri)) {
-            log.debug("필터를 적용하지 않는 URL 주소입니다. : requestUri = {}", requestUri);
+            log.debug("필터를 적용하지 않는 URL 주소입니다.");
             chain.doFilter(request, response);
             return;
         }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/sse/SseMessageSender.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/sse/SseMessageSender.java
@@ -5,6 +5,7 @@ import com.softeer.reacton.global.exception.code.SseErrorCode;
 import com.softeer.reacton.global.sse.dto.SseMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
@@ -18,13 +19,12 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class SseMessageSender {
 
+    @Value("${sse.message.base-url}")
+    private String sseMessageBaseUrl;
     private final WebClient webClient;
 
-    // TODO : 실제 배포 환경에 맞게 도메인 주소 변경
-    private final String sseMessageBaseUrl = "http://localhost:8081/sse/message";
-
     public void sendMessageToProfessor(Long courseId, SseMessage<?> message) {
-        String url = sseMessageBaseUrl + "/course/" + courseId;
+        String url = sseMessageBaseUrl + "course/" + courseId;
         try {
             webClient.post()
                     .uri(url, courseId)

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/sse/SseMessageSender.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/sse/SseMessageSender.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
@@ -35,7 +36,7 @@ public class SseMessageSender {
                     .retryWhen(Retry.backoff(2, Duration.ofSeconds(1))
                             .filter(throwable -> {
                                 log.debug("재시도 중입니다.");
-                                return throwable instanceof org.springframework.web.reactive.function.client.WebClientRequestException;
+                                return throwable instanceof WebClientRequestException;
                             }))
                     .onErrorResume(error -> {
                         log.warn("SSE 메시지 전송에 실패했습니다. : courseId = {}, messageType = {}, error = {}",
@@ -44,7 +45,7 @@ public class SseMessageSender {
                     })
                     .subscribe(); // 비동기적으로 처리
         } catch (Exception e) {
-            log.error("SSE 메시지 전송 중 예외 발생: {}", e.getMessage(), e);
+            log.error("SSE 메시지 전송 중 예외가 발생했습니다. : {}", e.getMessage());
             throw new BaseException(SseErrorCode.MESSAGE_SEND_FAILURE);
         }
     }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/sse/SseMessageSender.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/sse/SseMessageSender.java
@@ -1,0 +1,51 @@
+package com.softeer.reacton.global.sse;
+
+import com.softeer.reacton.global.exception.BaseException;
+import com.softeer.reacton.global.exception.code.SseErrorCode;
+import com.softeer.reacton.global.sse.dto.SseMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SseMessageSender {
+
+    private final WebClient webClient;
+
+    // TODO : 실제 배포 환경에 맞게 도메인 주소 변경
+    private final String sseMessageBaseUrl = "http://localhost:8081/sse/message";
+
+    public void sendMessageToProfessor(Long courseId, SseMessage<?> message) {
+        String url = sseMessageBaseUrl + "/course/" + courseId;
+        try {
+            webClient.post()
+                    .uri(url, courseId)
+                    .bodyValue(message)
+                    .retrieve()
+                    .bodyToMono(Void.class)
+                    .doOnSuccess(aVoid ->
+                            log.debug("SSE 메시지 전송에 성공했습니다. : courseId = {}", courseId))
+                    .retryWhen(Retry.backoff(2, Duration.ofSeconds(1))
+                            .filter(throwable -> {
+                                log.debug("재시도 중입니다.");
+                                return throwable instanceof org.springframework.web.reactive.function.client.WebClientRequestException;
+                            }))
+                    .onErrorResume(error -> {
+                        log.warn("SSE 메시지 전송에 실패했습니다. : courseId = {}, messageType = {}, error = {}",
+                                courseId, message.getMessageType(), error.getMessage());
+                        return Mono.empty();
+                    })
+                    .subscribe(); // 비동기적으로 처리
+        } catch (Exception e) {
+            log.error("SSE 메시지 전송 중 예외 발생: {}", e.getMessage(), e);
+            throw new BaseException(SseErrorCode.MESSAGE_SEND_FAILURE);
+        }
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/sse/dto/SseMessage.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/sse/dto/SseMessage.java
@@ -1,0 +1,13 @@
+package com.softeer.reacton.global.sse.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SseMessage<T> {
+    private String messageType;
+    private T data;
+}


### PR DESCRIPTION
## [BE] 학생 메시지 전송 API 구현

## #️⃣ 연관된 이슈

> #154 

## 📝 작업 내용

학생이 메시지를 메인 서버에 전송하고, 메인 서버에서 SSE 서버로 메시지 전송을 요청하는 기능 구현
- 메시지를 메인 서버에 전송
- 메시지 유효성 검증 후, 필요 시 database에 접근해 값 업데이트
- SSE 서버로 비동기 메시지 전송 요청
- 클라이언트에게는 database에 업데이트되었는지 여부를 알림
- 학생 Question, Request, Reaction 데이터 전송 기능 구현 완료

## 💬 리뷰 요구사항(선택)

- 질문 해결 여부를 나타내는 컬럼을 추가해, Question 테이블 내 컬럼을 수정해야 합니다. 테이블에 아래 쿼리 명령어를 직접 입력해서 테이블 컬럼을 업데이트해야 합니다.
```ALTER TABLE question DROP COLUMN status```
- 수업 생성 시 Request(요청) 데이터들을 함께 생성하도록 수정했습니다. 따라서 테스트할 때 반드시 새로운 수업을 생성한 뒤 테스트해야 합니다. 기존 수업에서 테스트를 진행할 경우 Request 데이터를 정상적으로 처리하지 못합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new endpoints allowing students to submit questions, reactions, and requests.
  - Enhanced course creation by auto-generating associated interaction requests for educators.
  - Launched a more robust real-time messaging mechanism for timely notifications.
  - Added detailed logging for better monitoring of requests and responses.

- **Refactor**
  - Streamlined API responses and consolidated student interaction controllers for a unified experience.
  - Improved type consistency and error feedback in messaging and access handling.

- **Chores**
  - Removed outdated endpoints to simplify the system and boost overall performance.
  - Updated URL access configurations to reflect new endpoint structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->