### PR TITLE
[BE] 질문 체크 기능 구현

### DIFF
--- a/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/controller/SseMessageController.java
+++ b/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/controller/SseMessageController.java
@@ -18,9 +18,18 @@ public class SseMessageController {
     private final SseService sseService;
 
     @PostMapping("/course/{courseId}")
-    public ResponseEntity<SuccessResponse> sendMessage(@PathVariable String courseId, @RequestBody MessageResponse<?> message) {
-        log.debug("메시지 전송을 요청합니다. : courseId = {}, type = {}", courseId, message.getMessageType());
+    public ResponseEntity<SuccessResponse> sendMessageToCourse(@PathVariable String courseId, @RequestBody MessageResponse<?> message) {
+        log.debug("교수에게 메시지 전송을 요청합니다. : courseId = {}, type = {}", courseId, message.getMessageType());
         sseService.sendMessage(courseId, message);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.of("성공적으로 전송했습니다."));
+    }
+
+    @PostMapping("/student/{studentId}")
+    public ResponseEntity<SuccessResponse> sendMessageToStudent(@PathVariable String studentId, @RequestBody MessageResponse<?> message) {
+        log.debug("학생에게 메시지 전송을 요청합니다. : studentId = {}, type = {}", studentId, message.getMessageType());
+        sseService.sendMessage(studentId, message);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.of("성공적으로 전송했습니다."));

--- a/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/service/SseService.java
+++ b/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/service/SseService.java
@@ -43,8 +43,8 @@ public class SseService {
         return openStudentConnection(sink, studentId, courseId);
     }
 
-    public void sendMessage(String courseId, MessageResponse<?> message) {
-        Sinks.Many<MessageResponse<?>> sink = sinks.get(courseId);
+    public void sendMessage(String id, MessageResponse<?> message) {
+        Sinks.Many<MessageResponse<?>> sink = sinks.get(id);
         if (sink == null) {
             log.debug("전송 대상을 찾지 못했습니다. : Receiver not found.");
             throw new BaseException(SseErrorCode.USER_NOT_FOUND);

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/StudentCourseController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/StudentCourseController.java
@@ -80,7 +80,7 @@ public class StudentCourseController {
 
         return ResponseEntity
                 .status(HttpStatus.SEE_OTHER)
-                .header(HttpHeaders.LOCATION, FRONTEND_BASE_URL + "students/classroom")
+                .header(HttpHeaders.LOCATION, FRONTEND_BASE_URL + "student/course")
                 .header(HttpHeaders.SET_COOKIE, jwtCookie.toString())
                 .build();
     }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/ProfessorQuestionController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/ProfessorQuestionController.java
@@ -1,0 +1,48 @@
+package com.softeer.reacton.domain.question;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/professors/questions")
+@Tag(name = "Professor Questions API", description = "교수 질문 관련 API")
+@RequiredArgsConstructor
+public class ProfessorQuestionController {
+
+    private final ProfessorQuestionService professorQuestionService;
+
+    @PostMapping("/check/{questionId}")
+    @Operation(
+            summary = "교수 질문 체크 전송",
+            description = "교수가 학생에게 질문 체크를 전송합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공적으로 전송했습니다."),
+                    @ApiResponse(responseCode = "404", description = "수업을 찾을 수 없습니다."),
+                    @ApiResponse(responseCode = "404", description = "질문을 찾을 수 없습니다."),
+                    @ApiResponse(responseCode = "409", description = "아직 수업이 시작되지 않았습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버와의 연결에 실패했습니다.")
+            }
+    )
+    public ResponseEntity<Void> checkQuestion(
+            @PathVariable("questionId") Long questionId) {
+        log.debug("교수 사용자가 질문 체크를 등록 및 전송합니다.");
+
+        professorQuestionService.sendQuestionCheck(questionId);
+
+        log.info("질문 체크를 성공적으로 등록했습니다.");
+
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/ProfessorQuestionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/ProfessorQuestionService.java
@@ -19,8 +19,8 @@ public class ProfessorQuestionService {
 
     private final QuestionRepository questionRepository;
     private final SseMessageSender sseMessageSender;
+    private final QuestionService questionService;
 
-    @Transactional
     public void sendQuestionCheck(Long questionId) {
         log.debug("질문 체크 처리를 시작합니다. : questionId = {}", questionId);
 
@@ -30,7 +30,7 @@ public class ProfessorQuestionService {
         String studentId = question.getStudentId();
 
         question.setIsComplete(true);
-        questionRepository.save(question);
+        questionService.save(question);
 
         QuestionCheckSseRequest questionCheckSseRequest = new QuestionCheckSseRequest(questionId);
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/ProfessorQuestionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/ProfessorQuestionService.java
@@ -7,7 +7,6 @@ import com.softeer.reacton.global.exception.code.CourseErrorCode;
 import com.softeer.reacton.global.exception.code.QuestionErrorCode;
 import com.softeer.reacton.global.sse.SseMessageSender;
 import com.softeer.reacton.global.sse.dto.SseMessage;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/ProfessorQuestionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/ProfessorQuestionService.java
@@ -1,0 +1,63 @@
+package com.softeer.reacton.domain.question;
+
+import com.softeer.reacton.domain.course.Course;
+import com.softeer.reacton.domain.question.dto.QuestionCheckSseRequest;
+import com.softeer.reacton.global.exception.BaseException;
+import com.softeer.reacton.global.exception.code.CourseErrorCode;
+import com.softeer.reacton.global.exception.code.QuestionErrorCode;
+import com.softeer.reacton.global.sse.SseMessageSender;
+import com.softeer.reacton.global.sse.dto.SseMessage;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProfessorQuestionService {
+
+    private final QuestionRepository questionRepository;
+    private final SseMessageSender sseMessageSender;
+
+    @Transactional
+    public void sendQuestionCheck(Long questionId) {
+        log.debug("질문 체크 처리를 시작합니다. : questionId = {}", questionId);
+
+        Question question = getQuestion(questionId);
+        Course course = question.getCourse();
+        checkIfOpen(course);
+        String studentId = question.getStudentId();
+
+        question.setIsComplete(true);
+        questionRepository.save(question);
+
+        QuestionCheckSseRequest questionCheckSseRequest = new QuestionCheckSseRequest(questionId);
+
+        log.debug("SSE 서버에 질문 체크 전송을 요청합니다.");
+        SseMessage<QuestionCheckSseRequest> sseMessage = new SseMessage<>("QUESTION_CHECK", questionCheckSseRequest);
+        sseMessageSender.sendMessage(studentId, sseMessage);
+
+        log.debug("질문 체크 처리가 완료되었습니다.");
+    }
+
+    private Question getQuestion(Long questionId) {
+        return questionRepository.findById(questionId)
+                .orElseThrow(() -> new BaseException(QuestionErrorCode.QUESTION_NOT_FOUND));
+    }
+
+    private Course getCourseByQuestionId(Long questionId) {
+        Course course = questionRepository.getCourseById(questionId);
+        if (course == null) {
+            log.debug("질문 체크를 처리하는 과정에서 발생한 에러입니다. : Question does not exist.");
+            throw new BaseException(QuestionErrorCode.QUESTION_NOT_FOUND);
+        }
+        return course;
+    }
+
+    private void checkIfOpen(Course course) {
+        if (!course.isActive()) {
+            throw new BaseException(CourseErrorCode.COURSE_NOT_ACTIVE);
+        }
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/ProfessorQuestionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/ProfessorQuestionService.java
@@ -46,15 +46,6 @@ public class ProfessorQuestionService {
                 .orElseThrow(() -> new BaseException(QuestionErrorCode.QUESTION_NOT_FOUND));
     }
 
-    private Course getCourseByQuestionId(Long questionId) {
-        Course course = questionRepository.getCourseById(questionId);
-        if (course == null) {
-            log.debug("질문 체크를 처리하는 과정에서 발생한 에러입니다. : Question does not exist.");
-            throw new BaseException(QuestionErrorCode.QUESTION_NOT_FOUND);
-        }
-        return course;
-    }
-
     private void checkIfOpen(Course course) {
         if (!course.isActive()) {
             throw new BaseException(CourseErrorCode.COURSE_NOT_ACTIVE);

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/Question.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/Question.java
@@ -3,10 +3,7 @@ package com.softeer.reacton.domain.question;
 import com.softeer.reacton.domain.course.Course;
 import com.softeer.reacton.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,6 +21,7 @@ public class Question extends BaseEntity {
     @Column(nullable = false, length = 600)
     private String content;
 
+    @Setter
     @Column(nullable = false)
     private Boolean isComplete;
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/QuestionRepository.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/QuestionRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -12,6 +13,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     List<Question> findByStudentIdAndCourse(String studentId, Course course);
 
     @Modifying
+    @Transactional
     @Query("UPDATE Question q SET q.isComplete = true " +
             "WHERE q.studentId = :studentId AND q.course = :course AND q.id = :questionId")
     int updateQuestion(@Param("studentId") String studentId, @Param("course") Course course, @Param("questionId") Long questionId);

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/QuestionRepository.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/QuestionRepository.java
@@ -2,11 +2,19 @@ package com.softeer.reacton.domain.question;
 
 import com.softeer.reacton.domain.course.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     List<Question> findByStudentIdAndCourse(String studentId, Course course);
+
+    @Modifying
+    @Query("UPDATE Question q SET q.isComplete = true " +
+            "WHERE q.studentId = :studentId AND q.course = :course AND q.id = :questionId")
+    int updateQuestion(@Param("studentId") String studentId, @Param("course") Course course, @Param("questionId") Long questionId);
 
     void deleteAllByCourse(Course course);
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/QuestionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/QuestionService.java
@@ -1,4 +1,17 @@
 package com.softeer.reacton.domain.question;
 
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+
+    @Transactional
+    public void save(Question question) {
+        questionRepository.save(question);
+    }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionController.java
@@ -77,4 +77,33 @@ public class StudentQuestionController {
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.of("질문을 성공적으로 등록했습니다.", response));
     }
+
+    @PostMapping("/check/{questionId}")
+    @Operation(
+            summary = "학생 질문 체크 전송",
+            description = "학생이 교수에게 질문 체크를 전송합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공적으로 전송했습니다."),
+                    @ApiResponse(responseCode = "404", description = "수업을 찾을 수 없습니다."),
+                    @ApiResponse(responseCode = "404", description = "질문을 찾을 수 없습니다."),
+                    @ApiResponse(responseCode = "409", description = "아직 수업이 시작되지 않았습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버와의 연결에 실패했습니다.")
+            }
+    )
+    public ResponseEntity<Void> checkQuestion(
+            @PathVariable("questionId") Long questionId,
+            HttpServletRequest request) {
+        log.debug("학생 사용자가 질문 체크를 등록 및 전송합니다.");
+
+        String studentId = (String) request.getAttribute("studentId");
+        Long courseId = (Long) request.getAttribute("courseId");
+
+        studentQuestionService.sendQuestionCheck(studentId, courseId, questionId);
+
+        log.info("질문 체크를 성공적으로 등록했습니다.");
+
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
+    }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionService.java
@@ -4,9 +4,11 @@ import com.softeer.reacton.domain.course.Course;
 import com.softeer.reacton.domain.course.CourseRepository;
 import com.softeer.reacton.domain.course.dto.CourseQuestionResponse;
 import com.softeer.reacton.domain.question.dto.QuestionAllResponse;
+import com.softeer.reacton.domain.question.dto.QuestionCheckSseRequest;
 import com.softeer.reacton.domain.question.dto.QuestionSendRequest;
 import com.softeer.reacton.global.exception.BaseException;
 import com.softeer.reacton.global.exception.code.CourseErrorCode;
+import com.softeer.reacton.global.exception.code.QuestionErrorCode;
 import com.softeer.reacton.global.sse.SseMessageSender;
 import com.softeer.reacton.global.sse.dto.SseMessage;
 import lombok.RequiredArgsConstructor;
@@ -61,10 +63,32 @@ public class StudentQuestionService {
 
         log.debug("SSE 서버에 질문 전송을 요청합니다.");
         SseMessage<CourseQuestionResponse> sseMessage = new SseMessage<>("QUESTION", courseQuestionResponse);
-        sseMessageSender.sendMessageToProfessor(courseId, sseMessage);
+        sseMessageSender.sendMessage(courseId.toString(), sseMessage);
 
         log.debug("질문 처리가 완료되었습니다.");
         return courseQuestionResponse;
+    }
+
+    @Transactional
+    public void sendQuestionCheck(String studentId, Long courseId, Long questionId) {
+        log.debug("질문 체크 처리를 시작합니다. : questionId = {}", questionId);
+
+        Course course = getCourse(courseId);
+        checkIfOpen(course);
+
+        int updatedRows = questionRepository.updateQuestion(studentId, course, questionId);
+        if (updatedRows == 0) {
+            log.debug("질문 체크를 처리하는 과정에서 발생한 에러입니다. : Question does not exist.");
+            throw new BaseException(QuestionErrorCode.QUESTION_NOT_FOUND);
+        }
+
+        QuestionCheckSseRequest questionCheckSseRequest = new QuestionCheckSseRequest(questionId);
+
+        log.debug("SSE 서버에 질문 체크 전송을 요청합니다.");
+        SseMessage<QuestionCheckSseRequest> sseMessage = new SseMessage<>("QUESTION_CHECK", questionCheckSseRequest);
+        sseMessageSender.sendMessage(courseId.toString(), sseMessage);
+
+        log.debug("질문 체크 처리가 완료되었습니다.");
     }
 
     private Course getCourse(Long courseId) {

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/StudentQuestionService.java
@@ -69,7 +69,6 @@ public class StudentQuestionService {
         return courseQuestionResponse;
     }
 
-    @Transactional
     public void sendQuestionCheck(String studentId, Long courseId, Long questionId) {
         log.debug("질문 체크 처리를 시작합니다. : questionId = {}", questionId);
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/dto/QuestionCheckSseRequest.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/question/dto/QuestionCheckSseRequest.java
@@ -1,0 +1,10 @@
+package com.softeer.reacton.domain.question.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class QuestionCheckSseRequest {
+    private Long id;
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/StudentReactionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/reaction/StudentReactionService.java
@@ -31,7 +31,7 @@ public class StudentReactionService {
 
         log.debug("SSE 서버에 반응 전송을 요청합니다.");
         SseMessage<ReactionSseRequest> sseMessage = new SseMessage<>("REACTION", reactionSseRequest);
-        sseMessageSender.sendMessageToProfessor(courseId, sseMessage);
+        sseMessageSender.sendMessage(courseId.toString(), sseMessage);
     }
 
     private Course getCourse(Long courseId) {

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/StudentRequestService.java
@@ -42,7 +42,7 @@ public class StudentRequestService {
 
         log.debug("SSE 서버에 요청 전송을 요청합니다.");
         SseMessage<RequestSseRequest> sseMessage = new SseMessage<>("REQUEST", requestSseRequest);
-        sseMessageSender.sendMessageToProfessor(courseId, sseMessage);
+        sseMessageSender.sendMessage(courseId.toString(), sseMessage);
     }
 
     private Course getCourse(Long courseId) {

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/QuestionErrorCode.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/QuestionErrorCode.java
@@ -1,0 +1,19 @@
+package com.softeer.reacton.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum QuestionErrorCode implements ErrorCode {
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 질문 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return name();
+    }
+}

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/sse/SseMessageSender.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/sse/SseMessageSender.java
@@ -1,7 +1,5 @@
 package com.softeer.reacton.global.sse;
 
-import com.softeer.reacton.global.exception.BaseException;
-import com.softeer.reacton.global.exception.code.SseErrorCode;
 import com.softeer.reacton.global.sse.dto.SseMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,28 +23,22 @@ public class SseMessageSender {
 
     public void sendMessage(String id, SseMessage<?> message) {
         String url = sseMessageBaseUrl + "course/" + id;
-        try {
-            webClient.post()
-                    .uri(url, id)
-                    .bodyValue(message)
-                    .retrieve()
-                    .bodyToMono(Void.class)
-                    .doOnSuccess(aVoid ->
-                            log.debug("SSE 메시지 전송에 성공했습니다. : courseId = {}", id))
-                    .retryWhen(Retry.backoff(2, Duration.ofSeconds(1))
-                            .filter(throwable -> {
-                                log.debug("재시도 중입니다.");
-                                return throwable instanceof WebClientRequestException;
-                            }))
-                    .onErrorResume(error -> {
-                        log.warn("SSE 메시지 전송에 실패했습니다. : courseId = {}, messageType = {}, error = {}",
-                                id, message.getMessageType(), error.getMessage());
-                        return Mono.empty();
-                    })
-                    .subscribe(); // 비동기적으로 처리
-        } catch (Exception e) {
-            log.error("SSE 메시지 전송 중 예외가 발생했습니다. : {}", e.getMessage());
-            throw new BaseException(SseErrorCode.MESSAGE_SEND_FAILURE);
-        }
+        webClient.post()
+                .uri(url, id)
+                .bodyValue(message)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .doOnSuccess(aVoid -> log.debug("SSE 메시지 전송에 성공했습니다. : courseId = {}", id))
+                .retryWhen(Retry.backoff(2, Duration.ofSeconds(1))
+                        .filter(throwable -> {
+                            log.debug("재시도 중입니다.");
+                            return throwable instanceof WebClientRequestException;
+                        }))
+                .onErrorResume(error -> {
+                    log.warn("SSE 메시지 전송에 실패했습니다. : courseId = {}, messageType = {}, error = {}",
+                            id, message.getMessageType(), error.getMessage());
+                    return Mono.empty();
+                })
+                .subscribe();
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/sse/SseMessageSender.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/sse/SseMessageSender.java
@@ -23,16 +23,16 @@ public class SseMessageSender {
     private String sseMessageBaseUrl;
     private final WebClient webClient;
 
-    public void sendMessageToProfessor(Long courseId, SseMessage<?> message) {
-        String url = sseMessageBaseUrl + "course/" + courseId;
+    public void sendMessage(String id, SseMessage<?> message) {
+        String url = sseMessageBaseUrl + "course/" + id;
         try {
             webClient.post()
-                    .uri(url, courseId)
+                    .uri(url, id)
                     .bodyValue(message)
                     .retrieve()
                     .bodyToMono(Void.class)
                     .doOnSuccess(aVoid ->
-                            log.debug("SSE 메시지 전송에 성공했습니다. : courseId = {}", courseId))
+                            log.debug("SSE 메시지 전송에 성공했습니다. : courseId = {}", id))
                     .retryWhen(Retry.backoff(2, Duration.ofSeconds(1))
                             .filter(throwable -> {
                                 log.debug("재시도 중입니다.");
@@ -40,7 +40,7 @@ public class SseMessageSender {
                             }))
                     .onErrorResume(error -> {
                         log.warn("SSE 메시지 전송에 실패했습니다. : courseId = {}, messageType = {}, error = {}",
-                                courseId, message.getMessageType(), error.getMessage());
+                                id, message.getMessageType(), error.getMessage());
                         return Mono.empty();
                     })
                     .subscribe(); // 비동기적으로 처리


### PR DESCRIPTION
## [BE] 질문 체크 기능 구현

## #️⃣ 연관된 이슈

#182 

## 📝 작업 내용

학생과 교수 모두 질문을 체크하고, 이를 바탕으로 SSE 메시지를 보내는 기능
- 질문 체크 API 요청
- Question 테이블 내 isComplete 업데이트
- 비동기 방식으로 상대방에게 SSE 메시지를 통해 질문 체크 알림 전송

## 💬 리뷰 요구사항(선택)

학생이 체크 버튼을 눌렀을 때와 교수가 체크 버튼을 눌렀을 때 database 접근 방식을 조금 다르게 구성했습니다.
- 학생의 경우 요청 시 questionId와 함께 쿠키 안에 studentId, courseId를 가지고 있기 때문에 update 1회만 수행하도록 설계했습니다.
- 교수의 경우 요청 시 questionId만 알고 있기 때문에 먼저 questionId를 이용해 course와 studentId를 가져온 뒤 question update를 수행하고, studentId를 바탕으로 SSE 메시지 요청을 보내도록 설계했습니다.
더 좋은 방식이 있으면 제안해 주셔도 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced targeted real-time messaging that now supports communications tailored for both courses and individual students.
  - Added endpoints enabling professors and students to check question statuses and receive immediate notifications.
  - Updated the course registration flow with revised redirection for a more intuitive navigation experience.
  - Introduced a new service for managing question-related functionalities, including status checks and updates.

- **Improvements**
  - Enhanced system logging and messaging consistency for optimal performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->