### PR TITLE
[BE] 교수 수업 종료 시 학생에게 알리는 기능 추가

### DIFF
--- a/back-end/reacton-classroom/build.gradle
+++ b/back-end/reacton-classroom/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
 }
 
 tasks.named('test') {

--- a/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/controller/SseConnectionController.java
+++ b/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/controller/SseConnectionController.java
@@ -2,6 +2,7 @@ package com.softeer.reacton_classroom.domain.sse.controller;
 
 import com.softeer.reacton_classroom.domain.sse.dto.MessageResponse;
 import com.softeer.reacton_classroom.domain.sse.service.SseService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,12 +22,20 @@ public class SseConnectionController {
 
     private final SseService sseService;
 
+    @Operation(
+            summary = "교수 SSE 연결 요청",
+            description = "교수가 SSE 연결을 요청합니다."
+    )
     @GetMapping(path = "/course/{courseId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<MessageResponse<?>>> subscribeCourse(@PathVariable String courseId) {
         log.debug("교수 SSE 연결을 요청합니다. : courseId = {}", courseId);
         return sseService.subscribeCourseMessages(courseId);
     }
 
+    @Operation(
+            summary = "학생 SSE 연결 요청",
+            description = "학생이 SSE 연결을 요청합니다."
+    )
     @GetMapping(path = "/student", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<MessageResponse<?>>> subscribeStudent(HttpServletRequest request) {
         String studentId = (String) request.getAttribute("studentId");

--- a/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/controller/SseMessageController.java
+++ b/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/controller/SseMessageController.java
@@ -3,6 +3,7 @@ package com.softeer.reacton_classroom.domain.sse.controller;
 import com.softeer.reacton_classroom.domain.sse.dto.MessageResponse;
 import com.softeer.reacton_classroom.domain.sse.service.SseService;
 import com.softeer.reacton_classroom.global.dto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -17,6 +18,10 @@ public class SseMessageController {
 
     private final SseService sseService;
 
+    @Operation(
+            summary = "SSE 메시지 전송 요청",
+            description = "SSE로 메시지 전송을 요청합니다."
+    )
     @PostMapping("/course/{courseId}")
     public ResponseEntity<SuccessResponse> sendMessage(@PathVariable String courseId, @RequestBody MessageResponse<?> message) {
         log.debug("메시지 전송을 요청합니다. : courseId = {}, type = {}", courseId, message.getMessageType());

--- a/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/controller/SseMessageController.java
+++ b/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/controller/SseMessageController.java
@@ -30,4 +30,17 @@ public class SseMessageController {
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.of("성공적으로 전송했습니다."));
     }
+
+    @Operation(
+            summary = "SSE 메시지 일괄 전송 요청",
+            description = "SSE로 메시지 일괄 전송을 요청합니다."
+    )
+    @PostMapping("/students/{courseId}")
+    public ResponseEntity<SuccessResponse> sendMessageToStudents(@PathVariable String courseId, @RequestBody MessageResponse<?> message) {
+        log.debug("메시지 일괄 전송을 요청합니다. : courseId = {}, type = {}", courseId, message.getMessageType());
+        sseService.sendMessageToStudents(courseId, message);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.of("성공적으로 전송했습니다."));
+    }
 }

--- a/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/service/SseService.java
+++ b/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/service/SseService.java
@@ -58,6 +58,12 @@ public class SseService {
         log.info("메시지 전송에 성공했습니다.");
     }
 
+    public void sendMessageToStudents(String courseId, MessageResponse<?> message) {
+        for (String studentId : courseStudentMap.get(courseId)) {
+            sendMessage(studentId, message);
+        }
+    }
+
     private Flux<ServerSentEvent<MessageResponse<?>>> openCourseConnection(Sinks.Many<MessageResponse<?>> sink, String courseId) {
         return sink.asFlux()
                 .map(data -> ServerSentEvent.<MessageResponse<?>>builder(data).build())
@@ -115,4 +121,3 @@ public class SseService {
         sink.tryEmitComplete();
     }
 }
-

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -16,6 +16,8 @@ import com.softeer.reacton.global.exception.code.CourseErrorCode;
 import com.softeer.reacton.global.exception.code.FileErrorCode;
 import com.softeer.reacton.global.exception.code.ProfessorErrorCode;
 import com.softeer.reacton.global.s3.S3Service;
+import com.softeer.reacton.global.sse.SseMessageSender;
+import com.softeer.reacton.global.sse.dto.SseMessage;
 import com.softeer.reacton.global.util.TimeUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +48,7 @@ public class ProfessorCourseService {
     private static final String FILE_DIRECTORY = "course-files/";
     private static final long MAX_FILE_SIZE = 100L * 1024 * 1024;
     private static final int PRESIGNED_URL_EXPIRATION_MINUTES = 1;
+    private final SseMessageSender sseMessageSender;
 
     public Map<String, String> getActiveCourseByUser(String oauthId) {
         log.debug("활성화된 수업을 조회합니다.");
@@ -155,6 +158,10 @@ public class ProfessorCourseService {
 
         Course course = getCourseByProfessor(oauthId, courseId);
         course.deactivate();
+
+        log.debug("SSE 서버에 수업 종료 메시지 전송을 요청합니다.");
+        SseMessage<Void> sseMessage = new SseMessage<>("COURSE_CLOSED", null);
+        sseMessageSender.sendMessageToAll(String.valueOf(courseId), sseMessage);
 
         log.info("수업이 종료 상태로 변경되었습니다. courseId = {}", courseId);
     }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/sse/SseMessageSender.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/sse/SseMessageSender.java
@@ -49,4 +49,31 @@ public class SseMessageSender {
             throw new BaseException(SseErrorCode.MESSAGE_SEND_FAILURE);
         }
     }
+
+    public void sendMessageToAll(String courseId, SseMessage<?> message) {
+        String url = sseMessageBaseUrl + "students/" + courseId;
+        try {
+            webClient.post()
+                    .uri(url, courseId)
+                    .bodyValue(message)
+                    .retrieve()
+                    .bodyToMono(Void.class)
+                    .doOnSuccess(aVoid ->
+                            log.debug("SSE 메시지 전송에 성공했습니다. : courseId = {}", courseId))
+                    .retryWhen(Retry.backoff(2, Duration.ofSeconds(1))
+                            .filter(throwable -> {
+                                log.debug("재시도 중입니다.");
+                                return throwable instanceof WebClientRequestException;
+                            }))
+                    .onErrorResume(error -> {
+                        log.warn("SSE 메시지 전송에 실패했습니다. : courseId = {}, messageType = {}, error = {}",
+                                courseId, message.getMessageType(), error.getMessage());
+                        return Mono.empty();
+                    })
+                    .subscribe(); // 비동기적으로 처리
+        } catch (Exception e) {
+            log.error("SSE 메시지 전송 중 예외가 발생했습니다. : {}", e.getMessage());
+            throw new BaseException(SseErrorCode.MESSAGE_SEND_FAILURE);
+        }
+    }
 }


### PR DESCRIPTION
## [BE] 교수 수업 종료 시 학생에게 알리는 기능 추가

## #️⃣ 연관된 이슈

#186 

## 📝 작업 내용

교수가 수업을 종료했을 때 해당 수업을 듣고 있는 모든 학생들에게 수업 종료 메시지를 SSE로 전송하는 기능
- 수업 종료 시 courseId를 담아 수업 종료 메시지 전송 요청
- SSE 서버에서 해당 courseId에 속한 모든 student들에게 수업 종료 메시지 전송
기타 SSE 관련 기능
- 초기 connection이 형성될 때 클라이언트에게 connection 메시지를 전송
- SSE 서버 Swagger 연동

## 💬 리뷰 요구사항(선택)
기타 SSE 관련 기능들은 프론트엔드 분들께서 요구하신 내용들이라 추가했습니다.
초기 connection이 형성될 때 클라이언트에게 메시지를 보내야 프론트엔드 측에서 관리가 가능하다고 합니다.
SSE 서버를 Swagger에 연동시키면서 properties에 추가 설정이 필요합니다. 자세한 내용은 대면으로 논의하면 좋을 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated an interactive API documentation interface for improved viewing of RESTful endpoints.
  - Introduced a bulk messaging endpoint to deliver real-time notifications to groups.
  - Enhanced real-time communication by sending an automatic initial confirmation upon connection.
  - Enabled automatic notifications to alert users when courses are closed.
  - Extended messaging capabilities to broadcast notifications to all relevant participants.

- **Documentation**
  - Refined API endpoint descriptions and usage guidelines for clearer integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->