### PR TITLE
[FE] 학생 반응하기 요청하기 로컬 스토리지 저장 기능 구현

### DIFF
--- a/front-end/src/pages/student/course/react/StudentReact.tsx
+++ b/front-end/src/pages/student/course/react/StudentReact.tsx
@@ -63,6 +63,7 @@ const StudentReact = ({ setModalType, openModal }: StudentReactProps) => {
         {CARD_List.map((item) => (
           <ReactCard
             key={item.type}
+            type={item.type}
             Icon={item.icon}
             onCardClick={() => handleCardClick(item.type)}
           />

--- a/front-end/src/pages/student/course/react/components/ReactCard.tsx
+++ b/front-end/src/pages/student/course/react/components/ReactCard.tsx
@@ -1,25 +1,35 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import S from './ReactCard.module.css';
 import useBlockTimer from '@/hooks/useBlockTimer';
+import { Reaction } from '@/core/model';
 
 type ReactCardProps = {
   Icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
   onCardClick: () => Promise<boolean>;
+  type: Reaction;
 };
 
-const ReactCard = ({ Icon, onCardClick }: ReactCardProps) => {
-  const [isSelected, setIsSelected] = useState<boolean>(false);
-  const { isBlocked, countdown } = useBlockTimer(
-    isSelected,
-    setIsSelected,
+const ReactCard = ({ type, Icon, onCardClick }: ReactCardProps) => {
+  const [isSelected, setIsSelected] = useState(false);
+  const { isBlocked, countdown, startBlock } = useBlockTimer(
+    `reactions_block_${type}`,
     10000,
     2000
   );
+
+  useEffect(() => {
+    if (isBlocked) {
+      setIsSelected(true);
+    } else {
+      setIsSelected(false);
+    }
+  }, [isBlocked]);
 
   const handleButtonClick = async () => {
     const success = await onCardClick();
     if (success) {
       setIsSelected(true);
+      startBlock();
     }
   };
 

--- a/front-end/src/pages/student/course/request/StudentRequest.tsx
+++ b/front-end/src/pages/student/course/request/StudentRequest.tsx
@@ -81,6 +81,7 @@ const StudentRequest = ({ setModalType, openModal }: StudentRequestProps) => {
       <div className={S.cardContainer}>
         {CARD_CONTENT.map((item) => (
           <RequestCard
+            type={item.type}
             key={item.type}
             onCardClick={() => handleCardClick(item.type)}
             title={item.title}

--- a/front-end/src/pages/student/course/request/components/RequestCard.tsx
+++ b/front-end/src/pages/student/course/request/components/RequestCard.tsx
@@ -1,12 +1,14 @@
+import { RequestType } from '@/core/model';
 import S from './RequestCard.module.css';
 import useBlockTimer from '@/hooks/useBlockTimer';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 type RequestCardProps = {
   onCardClick: () => Promise<boolean>;
   Icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
   title: string;
   description: string;
+  type: RequestType;
 };
 
 const RequestCard = ({
@@ -14,19 +16,28 @@ const RequestCard = ({
   Icon,
   title,
   description,
+  type,
 }: RequestCardProps) => {
   const [isSelected, setIsSelected] = useState<boolean>(false);
-  const { isBlocked, countdown } = useBlockTimer(
-    isSelected,
-    setIsSelected,
+  const { isBlocked, countdown, startBlock } = useBlockTimer(
+    `requests_block_${type}`,
     60000,
     2000
   );
+
+  useEffect(() => {
+    if (isBlocked) {
+      setIsSelected(true);
+    } else {
+      setIsSelected(false);
+    }
+  }, [isBlocked]);
 
   const handleButtonClick = async () => {
     const success = await onCardClick();
     if (success) {
       setIsSelected(true);
+      startBlock();
     }
   };
 

--- a/front-end/src/repository/classroomRepository.ts
+++ b/front-end/src/repository/classroomRepository.ts
@@ -36,8 +36,6 @@ class ClassroomRepository {
       }
     );
     await throwError(response);
-    const data = response.json();
-    return data;
   }
 
   async checkQuestionByStudent(questionId: string): Promise<void> {
@@ -52,8 +50,6 @@ class ClassroomRepository {
       }
     );
     await throwError(response);
-    const data = await response.json();
-    return data;
   }
 
   async sendQuestion(question: string): Promise<Question> {
@@ -69,7 +65,11 @@ class ClassroomRepository {
     });
     await throwError(response);
     const data = await response.json();
-    return data.data;
+    return {
+      id: data.data.id,
+      createdAt: data.data.createdAt,
+      content: data.data.content,
+    };
   }
 
   async sendRequest(request: string): Promise<void> {
@@ -104,9 +104,18 @@ class ClassroomRepository {
     const response = await fetch('/api/students/questions', {
       method: 'GET',
     });
-    await throwError(response);
+
+    await throwError(response); // 오류 처리
+
     const data = await response.json();
-    return data.data.questions;
+    const questions: Question[] = data.data.questions.map(
+      (question: Question) => ({
+        id: question.id,
+        createdAt: question.createdAt,
+        content: question.content,
+      })
+    );
+    return questions;
   }
 }
 


### PR DESCRIPTION


## #️⃣ 연관된 이슈
- #212 

## 📝 작업 내용

 학생 반응하기 요청하기 로컬 스토리지 저장 기능 구현
학생이 요청과 반응에는 한번씩 누르게 되면 서버의 부하를 생각하여 60초.10초 동안 못하도록 막았습니다.
하지만 각각의 초 단위를 서버에서 받아오는것이 아니기 때문에 새로 고침을 하게 되면 초기화가 되는 문제가 생겨서
로컬스토리지에 저장하여 사용하도록 구현 했습니다!




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Interactive cards for reactions and requests now include a dynamic, type-based timer that temporarily disables actions, helping prevent rapid repeated inputs.
  - Visual feedback has been enhanced to clearly indicate when an action is blocked until it becomes available again.
  - The handling of submitted questions has been streamlined to consistently display key details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->