### PR TITLE
[BE] 활성화된 수업 여러개 존재 가능 문제 해결 

### DIFF
--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
@@ -110,10 +110,6 @@ public class Course extends BaseEntity {
     }
 
     public void activate() {
-        if (this.isActive) {
-            log.warn("이미 시작 상태인 수업입니다. : isActive = true");
-            throw new BaseException(CourseErrorCode.COURSE_ALREADY_ACTIVE);
-        }
         this.isActive = true;
     }
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/CourseRepository.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/CourseRepository.java
@@ -4,11 +4,13 @@ import com.softeer.reacton.domain.professor.Professor;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 import java.util.Optional;
 
+@Repository
 public interface CourseRepository extends JpaRepository<Course, Long> {
 
     @Query("SELECT DISTINCT c FROM Course c " +
@@ -49,4 +51,7 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     void deleteByProfessor(Professor professor);
 
     Optional<Course> findByProfessorAndIsActiveTrue(Professor professor);
+
+    @Query("SELECT c FROM Course c WHERE c.professor = :professor AND c.isActive = true")
+    List<Course> findIsActiveCoursesByProfessor(@Param("professor") Professor professor);
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/CourseRepository.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/CourseRepository.java
@@ -50,7 +50,7 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 
     void deleteByProfessor(Professor professor);
 
-    Optional<Course> findByProfessorAndIsActiveTrue(Professor professor);
+    Optional<Course> findTopByProfessorAndIsActiveTrue(Professor professor);
 
     @Query("SELECT c FROM Course c WHERE c.professor = :professor AND c.isActive = true")
     List<Course> findIsActiveCoursesByProfessor(@Param("professor") Professor professor);

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -163,9 +163,9 @@ public class ProfessorCourseService {
         log.debug("시작을 요청한 수업의 활성화 상태입니다. : isActive = {}", wasActive);
 
         deactivateOtherCourses(oauthId, courseId);
-
-        professorCourseTransactionService.activateCourse(targetCourse, wasActive);
-
+        if( !wasActive ) {
+            professorCourseTransactionService.activateCourse(targetCourse);
+        }
         log.info("수업이 시작 상태로 변경되었습니다. courseId = {}", courseId);
     }
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -54,7 +54,7 @@ public class ProfessorCourseService {
         Professor professor = professorRepository.findByOauthId(oauthId)
                 .orElseThrow(() -> new BaseException(ProfessorErrorCode.PROFESSOR_NOT_FOUND));
 
-        Course course = courseRepository.findByProfessorAndIsActiveTrue(professor).orElse(null);
+        Course course = courseRepository.findTopByProfessorAndIsActiveTrue(professor).orElse(null);
         if (course != null) {
             List<CourseScheduleResponse> schedules = getSchedulesByCourseInOrder(course);
             return ActiveCourseResponse.of(course, schedules);

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseTransactionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseTransactionService.java
@@ -1,5 +1,6 @@
 package com.softeer.reacton.domain.course;
 
+import com.softeer.reacton.domain.question.QuestionRepository;
 import com.softeer.reacton.domain.request.Request;
 import com.softeer.reacton.domain.request.RequestRepository;
 import com.softeer.reacton.domain.schedule.Schedule;
@@ -17,6 +18,7 @@ public class ProfessorCourseTransactionService {
     private final CourseRepository courseRepository;
     private final ScheduleRepository scheduleRepository;
     private final RequestRepository requestRepository;
+    private final QuestionRepository questionRepository;
 
     @Transactional
     public long saveCourse(Course course) {
@@ -33,5 +35,15 @@ public class ProfessorCourseTransactionService {
         }
 
         return course.getId();
+    }
+
+    @Transactional
+    public void activateCourse(Course course, boolean wasActive) {
+        if (!wasActive) {
+            questionRepository.deleteAllByCourse(course);
+            requestRepository.resetCountByCourse(course);
+        }
+        course.activate();
+        courseRepository.save(course);
     }
 }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseTransactionService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseTransactionService.java
@@ -38,11 +38,10 @@ public class ProfessorCourseTransactionService {
     }
 
     @Transactional
-    public void activateCourse(Course course, boolean wasActive) {
-        if (!wasActive) {
-            questionRepository.deleteAllByCourse(course);
-            requestRepository.resetCountByCourse(course);
-        }
+    public void activateCourse(Course course) {
+        questionRepository.deleteAllByCourse(course);
+        requestRepository.resetCountByCourse(course);
+
         course.activate();
         courseRepository.save(course);
     }

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/RequestRepository.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/RequestRepository.java
@@ -16,4 +16,8 @@ public interface RequestRepository extends JpaRepository<Request, Long> {
             "  AND r.type = :type")
     int incrementCount(@Param("course") Course course,
                        @Param("type") String type);
+
+    @Modifying
+    @Query("UPDATE Request r SET r.count = 0 WHERE r.course = :course")
+    void resetCountByCourse(@Param("course") Course course);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#204 [BE] 활성화된 수업 여러개 존재 가능

## 📝 작업 내용

### 수업 시작 요청이 들어왔을 때 
1. 요청으로 들어온 수업의 활성화 상태 확인 (`wasActive`에 저장)
2. 로그인한 교수의 모든 활성화 상태인 수업 조회 후 비활성화 처리
3. `wasActive`가 false인 경우만 기존 질문 데이터 삭제 및 요청 데이터 count 값 0으로 초기화 후 활성화처리

### 활성화된 수업 조회
- 활성화된 수업이 여러개 존재하는 장애 상황이 생길 경우를 대비해 가장 첫번째로 조회되는 수업만 반환
