### PR TITLE
[FE] 학생 페이지 UI 버그 

### DIFF
--- a/front-end/src/pages/home/Home.module.css
+++ b/front-end/src/pages/home/Home.module.css
@@ -1,12 +1,98 @@
-.container {
+.homeLayout {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  height: 100vh;
+  padding: 175px 20px;
+  gap: 110px;
+  background-color: white;
 }
 
-.text {
-  font-size: 24px;
-  color: #333;
+.logo {
+  width: 160px;
+  height: 25px;
+}
+
+.buttonContainer {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.professorButton {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  word-break: keep-all;
+  font: var(--mobile-button1-bold);
+  padding: 16px;
+  background-color: var(--blue-400);
+  color: white;
+  border-radius: 8px;
+}
+
+.studentButton {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  word-break: keep-all;
+  font: var(--mobile-button1-bold);
+  padding: 16px;
+  background-color: var(--blue-400);
+  color: white;
+  border-radius: 8px;
+}
+
+/*스플릿 뷰 */
+@media all and (min-width: 600px) {
+  .homeLayout {
+    padding: 331px 20px;
+    gap: 160px;
+  }
+
+  .logo {
+    width: 435px;
+    height: 68px;
+  }
+
+  .buttonContainer {
+    gap: 20px;
+    max-width: 652px;
+  }
+
+  .professorButton {
+    font: var(--web-button3-bold);
+  }
+
+  .studentButton {
+    font: var(--web-button3-bold);
+  }
+}
+
+/*웹 뷰 */
+@media all and (min-width: 961px) {
+  .homeLayout {
+    padding: 272px 20px;
+    gap: 160px;
+  }
+
+  .logo {
+    width: 435px;
+    height: 68px;
+  }
+
+  .buttonContainer {
+    max-width: 908px;
+    gap: 40px;
+  }
+
+  .professorButton {
+    font: var(--web-button3-bold);
+  }
+
+  .studentButton {
+    font: var(--web-button3-bold);
+  }
 }

--- a/front-end/src/pages/home/Home.tsx
+++ b/front-end/src/pages/home/Home.tsx
@@ -1,14 +1,28 @@
+import { useNavigate } from 'react-router';
 import S from './Home.module.css';
+import Logo from '@/assets/icons/logo.svg?react';
 
 const Home = () => {
+  const navigate = useNavigate();
   return (
-    <div className={S.container}>
-      <a href="/professor/login" className={S.text}>
-        교수 시작
-      </a>
-      <a href="/student" className={S.text}>
-        학생 시작
-      </a>
+    <div className={S.homeLayout}>
+      <Logo className={S.logo} />
+      <div className={S.buttonContainer}>
+        <button
+          type="button"
+          className={S.professorButton}
+          onClick={() => navigate('/professor/login')}
+        >
+          교수 페이지로 이동
+        </button>
+        <button
+          type="button"
+          className={S.studentButton}
+          onClick={() => navigate('/student')}
+        >
+          학생 페이지로 이동
+        </button>
+      </div>
     </div>
   );
 };

--- a/front-end/src/pages/student/StudentLayout.tsx
+++ b/front-end/src/pages/student/StudentLayout.tsx
@@ -19,10 +19,36 @@ const StudentLayout = () => {
       }
     };
   }, []);
+
+  useEffect(() => {
+    const applyZoom = () => {
+      const width = window.outerWidth;
+
+      if (window.matchMedia('(min-width: 961px)').matches) {
+        document.body.style.zoom = `${width / 1920}`;
+        document.body.style.backgroundColor = 'var(--gray-200)';
+      } else if (window.matchMedia('(min-width: 600px)').matches) {
+        document.body.style.zoom = `${width / 960}`;
+        document.body.style.backgroundColor = 'var(--gray-100)';
+      } else {
+        document.body.style.zoom = '1';
+        document.body.style.backgroundColor = '';
+      }
+    };
+
+    applyZoom();
+    window.addEventListener('resize', applyZoom);
+
+    return () => {
+      window.removeEventListener('resize', applyZoom);
+      document.body.style.zoom = '1';
+    };
+  }, []);
+
   return (
-    <div>
+    <>
       <Outlet />
-    </div>
+    </>
   );
 };
 

--- a/front-end/src/pages/student/StudentLayout.tsx
+++ b/front-end/src/pages/student/StudentLayout.tsx
@@ -27,9 +27,6 @@ const StudentLayout = () => {
       if (window.matchMedia('(min-width: 961px)').matches) {
         document.body.style.zoom = `${width / 1920}`;
         document.body.style.backgroundColor = 'var(--gray-200)';
-      } else if (window.matchMedia('(min-width: 600px)').matches) {
-        document.body.style.zoom = `${width / 960}`;
-        document.body.style.backgroundColor = 'var(--gray-100)';
       } else {
         document.body.style.zoom = '1';
         document.body.style.backgroundColor = '';

--- a/front-end/src/pages/student/course/StudentCourse.module.css
+++ b/front-end/src/pages/student/course/StudentCourse.module.css
@@ -18,6 +18,7 @@
 .logo {
   width: 73px;
   height: 10px;
+  cursor: pointer;
 }
 
 .TabsContainer {

--- a/front-end/src/pages/student/course/StudentCourse.module.css
+++ b/front-end/src/pages/student/course/StudentCourse.module.css
@@ -1,6 +1,7 @@
 .courseLayout {
   width: 100%;
-  height: 100vh;
+  min-height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
 }
@@ -11,6 +12,7 @@
   flex-direction: column;
   align-items: center;
   padding-top: 20px;
+  background-color: white;
 }
 
 .logo {
@@ -56,7 +58,6 @@
 
 .tabLayout {
   width: 100%;
-  height: 100%;
 }
 
 /*스플릿 뷰 */

--- a/front-end/src/pages/student/course/StudentCourse.tsx
+++ b/front-end/src/pages/student/course/StudentCourse.tsx
@@ -77,7 +77,13 @@ const StudentCourse = () => {
       };
 
       eventSource.onerror = () => {
+        if (eventSource.readyState === EventSource.CONNECTING) {
+          return;
+        }
         eventSource.close();
+        eventSourceRef.current = null;
+        setModalType('sse');
+        openModal();
       };
 
       eventSourceRef.current = eventSource;
@@ -86,7 +92,11 @@ const StudentCourse = () => {
     connectSSE(); // 최초 연결
 
     return () => {
-      eventSourceRef.current?.close();
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current.onmessage = null;
+        eventSourceRef.current.onerror = null;
+      }
     };
   }, []);
 
@@ -140,6 +150,12 @@ const StudentCourse = () => {
       case 'closedCourse':
         return getStudentPopup(
           'closedCourse',
+          handleErrorModalClick,
+          handleErrorModalClick
+        );
+      case 'sse':
+        return getStudentPopup(
+          'sse',
           handleErrorModalClick,
           handleErrorModalClick
         );

--- a/front-end/src/pages/student/course/StudentCourse.tsx
+++ b/front-end/src/pages/student/course/StudentCourse.tsx
@@ -38,53 +38,56 @@ const StudentCourse = () => {
       try {
         const questionList = await classroomRepository.getQuestions();
         setQuestions(questionList);
-        const connectSSE = () => {
-          if (eventSourceRef.current) {
-            eventSourceRef.current.close();
-          }
-
-          const eventSource = new EventSource('/api/sse/connection/student', {
-            withCredentials: true,
-          });
-
-          eventSource.onmessage = (event) => {
-            const parsedData = JSON.parse(event.data); // JSON 형식으로 변환
-
-            // messageType에 따라 분기 처리
-            switch (parsedData.messageType) {
-              case 'QUESTION_CHECK':
-                setQuestions((prevQuestions) =>
-                  prevQuestions.filter((q) => q.id !== parsedData.data.id)
-                );
-                break;
-
-              case 'COURSE_CLOSED':
-                setModalType('closedCourse');
-                openModal();
-                break;
-
-              default:
-                break;
-            }
-          };
-
-          eventSource.onerror = () => {
-            eventSource.close();
-            connectSSE();
-          };
-          eventSourceRef.current = eventSource;
-        };
-
-        connectSSE(); // 최초 연결
-
-        return () => {
-          eventSourceRef.current?.close();
-        };
       } catch (error) {
         handleStudentError({ error, setModalType, openModal });
       }
     }
     fetchQuestions();
+  }, []);
+
+  useEffect(() => {
+    const connectSSE = () => {
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+      }
+
+      const eventSource = new EventSource('/api/sse/connection/student', {
+        withCredentials: true,
+      });
+
+      eventSource.onmessage = (event) => {
+        const parsedData = JSON.parse(event.data); // JSON 형식으로 변환
+
+        // messageType에 따라 분기 처리
+        switch (parsedData.messageType) {
+          case 'QUESTION_CHECK':
+            setQuestions((prevQuestions) =>
+              prevQuestions.filter((q) => q.id !== parsedData.data.id)
+            );
+            break;
+
+          case 'COURSE_CLOSED':
+            setModalType('closedCourse');
+            openModal();
+            break;
+
+          default:
+            break;
+        }
+      };
+
+      eventSource.onerror = () => {
+        eventSource.close();
+      };
+
+      eventSourceRef.current = eventSource;
+    };
+
+    connectSSE(); // 최초 연결
+
+    return () => {
+      eventSourceRef.current?.close();
+    };
   }, []);
 
   useEffect(() => {
@@ -154,7 +157,7 @@ const StudentCourse = () => {
     <>
       <div className={S.courseLayout}>
         <header className={S.headerContainer}>
-          <Logo className={S.logo} />
+          <Logo className={S.logo} onClick={() => navigate('/student')} />
           <div className={S.TabsContainer}>
             {TAB_OPTIONS.map(({ key, label }) => (
               <button

--- a/front-end/src/pages/student/course/StudentCourse.tsx
+++ b/front-end/src/pages/student/course/StudentCourse.tsx
@@ -21,8 +21,6 @@ const TAB_OPTIONS = [
   { key: 'question', label: '질문하기' },
 ];
 
-const SSE_URL = import.meta.env.VITE_API_URL;
-
 const StudentCourse = () => {
   const navigate = useNavigate();
   const [selectedTab, setSelectedTab] = useState(TAB_OPTIONS[0].key);
@@ -61,7 +59,7 @@ const StudentCourse = () => {
         eventSourceRef.current.close();
       }
 
-      const eventSource = new EventSource(`${SSE_URL}/sse/connection/student`, {
+      const eventSource = new EventSource('/api/sse/connection/student', {
         withCredentials: true,
       });
 

--- a/front-end/src/pages/student/course/question/StudentQuestion.module.css
+++ b/front-end/src/pages/student/course/question/StudentQuestion.module.css
@@ -45,7 +45,8 @@
 .questionContainer {
   display: flex;
   max-width: 390px;
-  overflow: scroll;
+  max-height: 350px;
+  overflow-y: scroll;
   width: 100%;
   flex-direction: column;
   align-items: end;

--- a/front-end/src/pages/student/home/StudentHome.module.css
+++ b/front-end/src/pages/student/home/StudentHome.module.css
@@ -4,6 +4,7 @@
   align-items: center;
   padding: 175px 20px;
   gap: 110px;
+  background-color: white;
 }
 
 .logo {

--- a/front-end/src/pages/student/home/StudentHome.tsx
+++ b/front-end/src/pages/student/home/StudentHome.tsx
@@ -21,7 +21,7 @@ const StudentHome = () => {
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const inputValue = e.target.value;
-    if (/^\d*$/.test(inputValue)) {
+    if (/^\d*$/.test(inputValue) && inputValue.length < 7) {
       setAdmissionCode(inputValue);
     }
   };

--- a/front-end/src/pages/student/home/StudentHome.tsx
+++ b/front-end/src/pages/student/home/StudentHome.tsx
@@ -66,10 +66,10 @@ const StudentHome = () => {
             university={classInfo.university}
             courseTitle={classInfo.name}
             coursePeople={classInfo.capacity}
-            courseDay={currentSchedule?.day}
+            courseDay={currentSchedule?.day || classInfo.schedule[0].day}
             courseNumber={classInfo.code}
-            startTime={currentSchedule?.start}
-            endTime={currentSchedule?.end}
+            startTime={currentSchedule?.start || classInfo.schedule[0].start}
+            endTime={currentSchedule?.end || classInfo.schedule[0].end}
             courseSort={classInfo.classType}
             onCheckClick={handleCheckClick}
           />

--- a/front-end/src/repository/classroomRepository.ts
+++ b/front-end/src/repository/classroomRepository.ts
@@ -1,3 +1,4 @@
+import { utcToKst } from './../utils/util';
 import { Question, Reaction } from '@/core/model';
 import { throwError } from './throwError';
 
@@ -73,7 +74,7 @@ class ClassroomRepository {
     const data = await response.json();
     return {
       id: data.data.id,
-      createdAt: data.data.createdAt,
+      createdAt: utcToKst(data.data.createdAt),
       content: data.data.content,
     };
   }
@@ -117,10 +118,11 @@ class ClassroomRepository {
     const questions: Question[] = data.data.questions.map(
       (question: Question) => ({
         id: question.id,
-        createdAt: question.createdAt,
+        createdAt: utcToKst(question.createdAt),
         content: question.content,
       })
     );
+
     return questions;
   }
 }

--- a/front-end/src/utils/studentPopupUtils.tsx
+++ b/front-end/src/utils/studentPopupUtils.tsx
@@ -27,6 +27,10 @@ const popupConfigs: Record<string, PopupConfig> = {
     title: '알 수 없는 오류입니다',
     content: '다시 한번 시도해주세요',
   },
+  sse: {
+    title: '서버에 오류가 발생했습니다',
+    content: '홈 화면으로 돌아갑니다',
+  },
 };
 
 export type PopupType = keyof typeof popupConfigs;

--- a/front-end/src/utils/studentPopupUtils.tsx
+++ b/front-end/src/utils/studentPopupUtils.tsx
@@ -67,6 +67,9 @@ export const handleStudentError = ({
     } else if (error.errorCode === 'COURSE_NOT_ACTIVE') {
       setModalType('notStart');
       openModal();
+    } else {
+      setModalType('unknown');
+      openModal();
     }
   } else if (error instanceof ServerError) {
     setModalType('server');

--- a/front-end/src/utils/util.ts
+++ b/front-end/src/utils/util.ts
@@ -146,3 +146,10 @@ export const filterCourse = (
       (courseType === '수업 종류' || courseType === course.classType)
   );
 };
+
+export const utcToKst = (isoString: string) => {
+  const date = new Date(isoString);
+  const kstHours = (date.getHours() + 9).toString().padStart(2, '0');
+  const kstMinutes = date.getMinutes().toString().padStart(2, '0');
+  return `${kstHours}:${kstMinutes}`;
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #219 

## 📝 작업 내용

이전에 빼먹은 자잘한거 구현 및 오류 수정  
- 질문 utc-> kst 구현 
- sse api proxy로 설정
- 학생 웹뷰 레이아웃 1920에 맞도록 구현
- 입장코드 6자리로 제한
- 수업 날짜가 다르더라도 강의가 열릴 시 제일 처음 날짜 뜨도록 구현
- 홈 logo navigate 구현
- 배경 설정 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dynamic zoom and background update effect that adjusts based on screen size.
  - Enabled interactive navigation by making the logo clickable, directing users to the student home page.

- **Style**
  - Refined page layouts with improved flexible sizing, header backgrounds, and scrollable content areas for a smoother viewing experience.
  - Enhanced the home page layout with new styles and responsive design adjustments.

- **Refactor**
  - Enhanced input validation and schedule modal data handling for a more robust user experience.
  - Upgraded error notifications and synchronized timestamp displays to local time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->