### PR TITLE
[BE] SSE 연결 관련 문제 개선

### DIFF
--- a/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/service/SseService.java
+++ b/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/service/SseService.java
@@ -23,12 +23,14 @@ public class SseService {
     private final Map<String, Sinks.Many<MessageResponse<?>>> sinks = new ConcurrentHashMap<>();
     private final Map<String, Set<String>> courseStudentMap = new ConcurrentHashMap<>();
     private final int MAX_CONNECTION_TIMEOUT_MINUTES = 10;
+    private final int RETRY_INTERVAL_SECONDS = 1;
 
     public Flux<ServerSentEvent<MessageResponse<?>>> subscribeCourseMessages(String courseId) {
         Sinks.Many<MessageResponse<?>> sink = sinks.computeIfAbsent(courseId, k -> Sinks.many().multicast().onBackpressureBuffer());
         courseStudentMap.computeIfAbsent(courseId, k -> ConcurrentHashMap.newKeySet());
         MessageResponse<?> initMessage = new MessageResponse<>("CONNECTION_ESTABLISHED", null);
         ServerSentEvent<MessageResponse<?>> initEvent = ServerSentEvent.<MessageResponse<?>>builder()
+                .retry(Duration.ofSeconds(RETRY_INTERVAL_SECONDS))
                 .data(initMessage)
                 .build();
 
@@ -45,6 +47,7 @@ public class SseService {
         courseStudentMap.get(courseId).add(studentId);
         MessageResponse<?> initMessage = new MessageResponse<>("CONNECTION_ESTABLISHED", null);
         ServerSentEvent<MessageResponse<?>> initEvent = ServerSentEvent.<MessageResponse<?>>builder()
+                .retry(Duration.ofSeconds(RETRY_INTERVAL_SECONDS))
                 .data(initMessage)
                 .build();
 


### PR DESCRIPTION
## [BE] SSE 연결 관련 문제 개선

## #️⃣ 연관된 이슈

#230 

## 📝 작업 내용

프론트엔드 측에서 요구한 내용을 바탕으로 작업함.
- 클라이언트 측에서 연결 실패 시 interval 없이 계속 재연결 시도를 하는 현상이 있어, 서버 측에서 재연결 간격을 설정하는 기능을 추가
  - 재연결 간격 1초로 설정

## 💬 리뷰 요구사항(선택)

연결 실패 시 자동 재연결을 시도하는 기능은 현재 프론트엔드 측에서 구현되어 있습니다. 따라서 실제로 연결 실패 시 1초 뒤에 재연결을 수행하는지 확인하기 위해서는 프론트엔드와 연동된 환경에서 테스트를 진행해야 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the reliability of live update streams by introducing an automatic retry mechanism that reattempts event delivery after brief interruptions, ensuring a smoother real-time experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->