### PR TITLE
[BE] 숫자 관련 오버플로우에 대한 예외 처리

### DIFF
--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/Course.java
@@ -10,6 +10,8 @@ import com.softeer.reacton.global.entity.BaseEntity;
 import com.softeer.reacton.global.exception.BaseException;
 import com.softeer.reacton.global.exception.code.CourseErrorCode;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,6 +37,8 @@ public class Course extends BaseEntity {
     private String courseCode;
 
     @Column(nullable = false)
+    @Min(1)
+    @Max(1000)
     private int capacity;
 
     @Column(nullable = false, length = 100)

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/dto/CourseRequest.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/dto/CourseRequest.java
@@ -19,6 +19,8 @@ public class CourseRequest {
     private String courseCode;
 
     @Positive(message = "수업 정원이 입력되지 않았습니다.")
+    @Min(value = 1, message = "수업 정원은 1명 이상이어야 합니다.")
+    @Max(value = 1000, message = "수업 정원은 1000명 이하여야 합니다.")
     private int capacity;
 
     @NotBlank(message = "대학 이름이 입력되지 않았습니다.")

--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/RequestService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/request/RequestService.java
@@ -8,6 +8,7 @@ import com.softeer.reacton.global.exception.code.RequestErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -24,10 +25,15 @@ public class RequestService {
         checkIfOpen(course);
 
         log.debug("요청을 저장합니다.");
-        int updatedRows = requestRepository.incrementCount(course, content);
-        if (updatedRows == 0) {
-            log.debug("요청 데이터를 처리하는 과정에서 발생한 에러입니다. : Request does not exist.");
-            throw new BaseException(RequestErrorCode.REQUEST_NOT_FOUND);
+        try {
+            int updatedRows = requestRepository.incrementCount(course, content);
+            if (updatedRows == 0) {
+                log.debug("요청 데이터를 처리하는 과정에서 발생한 에러입니다. : Request does not exist.");
+                throw new BaseException(RequestErrorCode.REQUEST_NOT_FOUND);
+            }
+        } catch (DataIntegrityViolationException e) {
+            log.debug("요청 데이터를 처리하는 과정에서 발생한 에러입니다. : {}", e.getMessage());
+            throw new BaseException(RequestErrorCode.REQUEST_OVERFLOW);
         }
     }
 

--- a/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/RequestErrorCode.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/global/exception/code/RequestErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum RequestErrorCode implements ErrorCode {
-    REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "요청 데이터를 찾을 수 없습니다.");
+    REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "요청 데이터를 찾을 수 없습니다."),
+    REQUEST_OVERFLOW(HttpStatus.BAD_REQUEST, "요청 횟수를 초과했습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## [BE] 숫자 관련 오버플로우에 대한 예외 처리

## #️⃣ 연관된 이슈

#229 

## 📝 작업 내용

오버플로우가 발생 가능한 문제가 발견되어, 이를 방지하기 위한 조치 도입
- 수업 정원 : 사용자가 입력할 때 입력값에 제한을 둠
  - 최소 1명, 최대 1000명으로 설정

## 💬 리뷰 요구사항(선택)

추가로 Request의 count에 대해서 오버플로우 방지가 되어 있지 않습니다. count의 경우 요청 한 번당 1이 증가하고, 매 수업 마다 0으로 초기화되는 점을 고려해, 오버플로우 임계점인 2,147,483,647에 도달하지 않을 것이라 예상했습니다. 오히려 오버플로우 방지를 하게 될 경우 db 접근 시 count값을 조회해야 하기 때문에 성능 저하가 있을 수 있다고 생각했습니다. 따라서 오버플로우 방지를 취하지 않았는데, 이에 대해 어떻게 생각하시는지 궁금합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced course capacity validation to ensure values must be between 1 and 1000.
	- Users will receive clear, immediate feedback if an invalid capacity is entered, promoting a smoother data entry experience.
	- Added a new error handling case for request overflow scenarios, improving user experience during high request counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->