### PR TITLE
[FE] useTemporaryState custom hook 구현

### DIFF
--- a/front-end/src/hooks/useTemporaryState.ts
+++ b/front-end/src/hooks/useTemporaryState.ts
@@ -1,19 +1,19 @@
 import { useEffect, useState, useRef } from 'react';
 
 type useTemporaryStateProps = {
-  type?: string;
+  storageKey?: string;
   duration: number;
   persist: boolean;
 };
 
 const useTemporaryState = ({
-  type,
+  storageKey,
   duration,
   persist = false,
 }: useTemporaryStateProps) => {
   // persist가 true면 localStorage 사용, 아니면 0으로 초기화
   const storedCountdown =
-    persist && type ? Number(localStorage.getItem(type)) || 0 : 0;
+    persist && storageKey ? Number(localStorage.getItem(storageKey)) || 0 : 0;
   const initialCountdown = storedCountdown > 0 ? storedCountdown : 0;
 
   const [isActive, setIsActive] = useState(initialCountdown > 0);
@@ -23,7 +23,7 @@ const useTemporaryState = ({
 
   // persist가 true이고 localStorage에 값이 있으면 countdown 시작
   useEffect(() => {
-    if (persist && type && initialCountdown > 0) {
+    if (persist && storageKey && initialCountdown > 0) {
       setIsActive(true);
       startCountdown(initialCountdown);
     }
@@ -31,26 +31,27 @@ const useTemporaryState = ({
     return () => {
       clearInterval(countdownIntervalRef.current!);
     };
-  }, [type, duration, persist]);
+  }, [storageKey, duration, persist]);
 
   // 카운트 다운 함수
   const startCountdown = (duration: number) => {
     setCountdown(duration);
-    if (persist && type) localStorage.setItem(type, duration.toString());
+    if (persist && storageKey)
+      localStorage.setItem(storageKey, duration.toString());
 
     countdownIntervalRef.current = window.setInterval(() => {
       setCountdown((prev) => {
         if (prev <= 1) {
           clearInterval(countdownIntervalRef.current!);
-          if (persist && type) {
-            localStorage.setItem(type, '0');
+          if (persist && storageKey) {
+            localStorage.setItem(storageKey, '0');
             setIsActive(false);
           }
           return 0;
         }
         const newCountdown = prev - 1;
-        if (persist && type)
-          localStorage.setItem(type, newCountdown.toString());
+        if (persist && storageKey)
+          localStorage.setItem(storageKey, newCountdown.toString());
         return newCountdown;
       });
     }, 1000);

--- a/front-end/src/hooks/useTemporaryState.ts
+++ b/front-end/src/hooks/useTemporaryState.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState, useRef } from 'react';
+
+type useTemporaryStateProps = {
+  type?: string;
+  duration: number;
+  persist: boolean;
+};
+
+const useTemporaryState = ({
+  type,
+  duration,
+  persist = false,
+}: useTemporaryStateProps) => {
+  // persist가 true면 localStorage 사용, 아니면 0으로 초기화
+  const storedCountdown =
+    persist && type ? Number(localStorage.getItem(type)) || 0 : 0;
+  const initialCountdown = storedCountdown > 0 ? storedCountdown : 0;
+
+  const [isActive, setIsActive] = useState(initialCountdown > 0);
+  const [countdown, setCountdown] = useState(initialCountdown);
+
+  const countdownIntervalRef = useRef<number | null>(null);
+
+  // persist가 true이고 localStorage에 값이 있으면 countdown 시작
+  useEffect(() => {
+    if (persist && type && initialCountdown > 0) {
+      setIsActive(true);
+      startCountdown(initialCountdown);
+    }
+
+    return () => {
+      clearInterval(countdownIntervalRef.current!);
+    };
+  }, [type, duration, persist]);
+
+  // 카운트 다운 함수
+  const startCountdown = (duration: number) => {
+    setCountdown(duration);
+    if (persist && type) localStorage.setItem(type, duration.toString());
+
+    countdownIntervalRef.current = window.setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          clearInterval(countdownIntervalRef.current!);
+          if (persist && type) {
+            localStorage.setItem(type, '0');
+            setIsActive(false);
+          }
+          return 0;
+        }
+        const newCountdown = prev - 1;
+        if (persist && type)
+          localStorage.setItem(type, newCountdown.toString());
+        return newCountdown;
+      });
+    }, 1000);
+  };
+
+  // 외부에서 호출할 블록 시작 함수 (즉시 실행)
+  const trigger = () => {
+    if (isActive) return;
+    setIsActive(true);
+    startCountdown(duration);
+  };
+
+  return { isActive, countdown, trigger };
+};
+
+export default useTemporaryState;

--- a/front-end/src/hooks/useTemporaryState.ts
+++ b/front-end/src/hooks/useTemporaryState.ts
@@ -3,17 +3,16 @@ import { useEffect, useState, useRef } from 'react';
 type useTemporaryStateProps = {
   storageKey?: string;
   duration: number;
-  persist: boolean;
 };
 
 const useTemporaryState = ({
   storageKey,
   duration,
-  persist = false,
 }: useTemporaryStateProps) => {
-  // persist가 true면 localStorage 사용, 아니면 0으로 초기화
-  const storedCountdown =
-    persist && storageKey ? Number(localStorage.getItem(storageKey)) || 0 : 0;
+  // storageKey가 있으면 localStorage 사용, 아니면 0으로 초기화
+  const storedCountdown = storageKey
+    ? Number(localStorage.getItem(storageKey)) || 0
+    : 0;
   const initialCountdown = storedCountdown > 0 ? storedCountdown : 0;
 
   const [isActive, setIsActive] = useState(initialCountdown > 0);
@@ -21,9 +20,9 @@ const useTemporaryState = ({
 
   const countdownIntervalRef = useRef<number | null>(null);
 
-  // persist가 true이고 localStorage에 값이 있으면 countdown 시작
+  //storageKey가 있으면 localStorage에 값이 있으면 countdown 시작
   useEffect(() => {
-    if (persist && storageKey && initialCountdown > 0) {
+    if (storageKey && initialCountdown > 0) {
       setIsActive(true);
       startCountdown(initialCountdown);
     }
@@ -31,26 +30,25 @@ const useTemporaryState = ({
     return () => {
       clearInterval(countdownIntervalRef.current!);
     };
-  }, [storageKey, duration, persist]);
+  }, [storageKey, duration]);
 
   // 카운트 다운 함수
   const startCountdown = (duration: number) => {
     setCountdown(duration);
-    if (persist && storageKey)
-      localStorage.setItem(storageKey, duration.toString());
+    if (storageKey) localStorage.setItem(storageKey, duration.toString());
 
     countdownIntervalRef.current = window.setInterval(() => {
       setCountdown((prev) => {
         if (prev <= 1) {
           clearInterval(countdownIntervalRef.current!);
-          if (persist && storageKey) {
+          if (storageKey) {
             localStorage.setItem(storageKey, '0');
             setIsActive(false);
           }
           return 0;
         }
         const newCountdown = prev - 1;
-        if (persist && storageKey)
+        if (storageKey)
           localStorage.setItem(storageKey, newCountdown.toString());
         return newCountdown;
       });

--- a/front-end/src/pages/student/course/react/components/ReactCard.module.css
+++ b/front-end/src/pages/student/course/react/components/ReactCard.module.css
@@ -35,7 +35,7 @@
 }
 
 .active {
-  animation: activeAnimation 0.4s ease-in-out forwards;
+  animation: activeAnimation 2s ease-in-out forwards;
 }
 
 .blocked {

--- a/front-end/src/pages/student/course/react/components/ReactCard.tsx
+++ b/front-end/src/pages/student/course/react/components/ReactCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import S from './ReactCard.module.css';
-import useBlockTimer from '@/hooks/useBlockTimer';
 import { Reaction } from '@/core/model';
+import useTemporaryState from '@/hooks/useTemporaryState';
 
 type ReactCardProps = {
   Icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
@@ -11,36 +11,36 @@ type ReactCardProps = {
 
 const ReactCard = ({ type, Icon, onCardClick }: ReactCardProps) => {
   const [isSelected, setIsSelected] = useState(false);
-  const { isBlocked, countdown, startBlock } = useBlockTimer(
-    `reactions_block_${type}`,
-    10000,
-    2000
-  );
+  const { isActive, countdown, trigger } = useTemporaryState({
+    type: `reactions_block_${type}`,
+    duration: 10,
+    persist: true,
+  });
 
   useEffect(() => {
-    if (isBlocked) {
+    if (isActive) {
       setIsSelected(true);
     } else {
       setIsSelected(false);
     }
-  }, [isBlocked]);
+  }, [isActive]);
 
   const handleButtonClick = async () => {
     const success = await onCardClick();
     if (success) {
-      setIsSelected(true);
-      startBlock();
+      trigger();
     }
   };
 
   return (
     <button
-      className={`${S.cardContainer} ${isSelected ? S.active : ''} ${isBlocked ? S.blocked : ''} `}
-      disabled={!!isSelected || isBlocked}
-      onClick={handleButtonClick}
+      className={`${S.cardContainer} ${isSelected ? S.active : ''} ${isActive ? S.blocked : ''} `}
+      disabled={!!isSelected || isActive}
+      onClick={() => setIsSelected(true)}
+      onAnimationEnd={handleButtonClick}
     >
       <Icon className={S.icon}></Icon>
-      {isBlocked && <div className={S.countdownText}>{countdown}</div>}
+      {isActive && <div className={S.countdownText}>{countdown}</div>}
     </button>
   );
 };

--- a/front-end/src/pages/student/course/react/components/ReactCard.tsx
+++ b/front-end/src/pages/student/course/react/components/ReactCard.tsx
@@ -16,7 +16,7 @@ const ReactCard = ({ type, Icon, onCardClick }: ReactCardProps) => {
     countdown,
     trigger,
   } = useTemporaryState({
-    type: `reactions_block_${type}`,
+    storageKey: `reactions_block_${type}`,
     duration: 10,
     persist: true,
   });

--- a/front-end/src/pages/student/course/react/components/ReactCard.tsx
+++ b/front-end/src/pages/student/course/react/components/ReactCard.tsx
@@ -18,7 +18,6 @@ const ReactCard = ({ type, Icon, onCardClick }: ReactCardProps) => {
   } = useTemporaryState({
     storageKey: `reactions_block_${type}`,
     duration: 10,
-    persist: true,
   });
 
   useEffect(() => {

--- a/front-end/src/pages/student/course/react/components/ReactCard.tsx
+++ b/front-end/src/pages/student/course/react/components/ReactCard.tsx
@@ -11,19 +11,23 @@ type ReactCardProps = {
 
 const ReactCard = ({ type, Icon, onCardClick }: ReactCardProps) => {
   const [isSelected, setIsSelected] = useState(false);
-  const { isActive, countdown, trigger } = useTemporaryState({
+  const {
+    isActive: isBlocked,
+    countdown,
+    trigger,
+  } = useTemporaryState({
     type: `reactions_block_${type}`,
     duration: 10,
     persist: true,
   });
 
   useEffect(() => {
-    if (isActive) {
+    if (isBlocked) {
       setIsSelected(true);
     } else {
       setIsSelected(false);
     }
-  }, [isActive]);
+  }, [isBlocked]);
 
   const handleButtonClick = async () => {
     const success = await onCardClick();
@@ -34,13 +38,13 @@ const ReactCard = ({ type, Icon, onCardClick }: ReactCardProps) => {
 
   return (
     <button
-      className={`${S.cardContainer} ${isSelected ? S.active : ''} ${isActive ? S.blocked : ''} `}
-      disabled={!!isSelected || isActive}
+      className={`${S.cardContainer} ${isSelected ? S.active : ''} ${isBlocked ? S.blocked : ''} `}
+      disabled={!!isSelected || isBlocked}
       onClick={() => setIsSelected(true)}
       onAnimationEnd={handleButtonClick}
     >
       <Icon className={S.icon}></Icon>
-      {isActive && <div className={S.countdownText}>{countdown}</div>}
+      {isBlocked && <div className={S.countdownText}>{countdown}</div>}
     </button>
   );
 };

--- a/front-end/src/pages/student/course/request/components/RequestCard.module.css
+++ b/front-end/src/pages/student/course/request/components/RequestCard.module.css
@@ -19,14 +19,18 @@
     transform: scale(1);
     background-color: initial;
   }
-  100% {
+  50% {
     transform: scale(1.08);
+    background-color: var(--blue-200);
+  }
+  100% {
+    transform: scale(1);
     background-color: var(--blue-200);
   }
 }
 
 .active {
-  animation: activeAnimation 0.4s ease-in-out forwards;
+  animation: activeAnimation 2s ease-in-out forwards;
 }
 
 .blocked {

--- a/front-end/src/pages/student/course/request/components/RequestCard.tsx
+++ b/front-end/src/pages/student/course/request/components/RequestCard.tsx
@@ -19,19 +19,23 @@ const RequestCard = ({
   type,
 }: RequestCardProps) => {
   const [isSelected, setIsSelected] = useState<boolean>(false);
-  const { isActive, countdown, trigger } = useTemporaryState({
+  const {
+    isActive: isBlocked,
+    countdown,
+    trigger,
+  } = useTemporaryState({
     type: `requests_block_${type}`,
     duration: 60,
     persist: true,
   });
 
   useEffect(() => {
-    if (isActive) {
+    if (isBlocked) {
       setIsSelected(true);
     } else {
       setIsSelected(false);
     }
-  }, [isActive]);
+  }, [isBlocked]);
 
   const handleButtonClick = async () => {
     const success = await onCardClick();
@@ -42,10 +46,10 @@ const RequestCard = ({
 
   return (
     <button
-      className={`${S.cardContainer} ${isSelected ? S.active : ''} ${isActive ? S.blocked : ''} `}
+      className={`${S.cardContainer} ${isSelected ? S.active : ''} ${isBlocked ? S.blocked : ''} `}
       onClick={() => setIsSelected(true)}
       onAnimationEnd={handleButtonClick}
-      disabled={!!isSelected || isActive}
+      disabled={!!isSelected || isBlocked}
     >
       <div className={S.iconBg}>
         <Icon className={S.icon} />
@@ -54,7 +58,7 @@ const RequestCard = ({
         <div className={S.cardTitle}>{title}</div>
         <div className={S.cardDesc}>{description}</div>
       </div>
-      {isActive && <div className={S.countdownText}>{countdown}</div>}
+      {isBlocked && <div className={S.countdownText}>{countdown}</div>}
     </button>
   );
 };

--- a/front-end/src/pages/student/course/request/components/RequestCard.tsx
+++ b/front-end/src/pages/student/course/request/components/RequestCard.tsx
@@ -26,7 +26,6 @@ const RequestCard = ({
   } = useTemporaryState({
     storageKey: `requests_block_${type}`,
     duration: 60,
-    persist: true,
   });
 
   useEffect(() => {

--- a/front-end/src/pages/student/course/request/components/RequestCard.tsx
+++ b/front-end/src/pages/student/course/request/components/RequestCard.tsx
@@ -24,7 +24,7 @@ const RequestCard = ({
     countdown,
     trigger,
   } = useTemporaryState({
-    type: `requests_block_${type}`,
+    storageKey: `requests_block_${type}`,
     duration: 60,
     persist: true,
   });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #228 

## 📝 작업 내용

학생 페이지 에서 반응하기와 요청하기 버튼을 클릭해 api 요청을 보낼때
일정시간동안 버튼을 비활성화 하면서 카운트다운 하는 기능이 있습니다.

그래서 어떤식으로 만들까 고민해보니 애니메이션 이후 개발자가 설정한 시간만큼만 state를 유지하는것이니깐  범용성을 생각하여  원하는 만큼의 시간을 넣으면 해당 시간만큼 state를 유지시킬 수 있는 커스텀hook을 만들어야겠다 라고 생각이 들어 구현하였습니다.

### 기능 
- state를 props값에 따라 몇초동안 유지시킬지 결정
- trigger함수를 통해 원할때 state 유지
- 새로고침을 하는경우 초기화 되기 때문에 localStorage에 저장할 수 있도록 구현(저장 안할 수 도 있음)

## 사용 가능한 부분
- 알림 & 팝업 자동 닫기
- 인증번호 타이머
- 블록으로 일정시간동안 클릭 막기 




## 💬 리뷰 요구사항(선택)

조금더 고려할 사항이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a custom React hook for managing an interactive countdown timer with optional state persistence.

- **Style**
  - Extended the active state animation duration for a smoother, more noticeable visual effect.

- **Refactor**
  - Updated card interaction logic to unify countdown display and selection behavior across different course components, transitioning from the previous timer management approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->