### PR TITLE
수업 생성시 입장 코드 6자리로 고정

### DIFF
--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -357,7 +357,7 @@ public class ProfessorCourseService {
     }
 
     private int generateUniqueAccessCode() {
-        return 100000 + secureRandom.nextInt(1000000); // 100000~999999
+        return 100000 + secureRandom.nextInt(900000); // 100000~999999
     }
 
     private boolean validateFile(MultipartFile file) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#248 [BE] 입장코드 6자리 초과하여 생성되는 문제

## 📝 작업 내용

### 기존 코드
private int generateUniqueAccessCode() {
        return 100000 + secureRandom.nextInt(1000000); 
 }
### 수정 사항
- `nextInt()` 함수의 값을 900000으로 수정하여 100000~999999 범위에서 입장 코드 생성 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the system’s access code generation so that all course access codes now consistently follow a standard 6-digit format. This change ensures a more predictable and uniform experience when accessing course-related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->