### PR TITLE
[BE] 오늘 수업 수정 시 오늘 날짜에 해당하는 Schedule만 표기되는 문제 해결

### DIFF
--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/ProfessorCourseService.java
@@ -303,7 +303,7 @@ public class ProfessorCourseService {
                 .filter(course -> hasScheduleInDay(course, currentDay))
                 .sorted(Comparator
                         .comparing(course -> getEarliestStartTime(course, currentDay)))
-                .map(course -> CourseSummaryResponse.of(course, getSchedulesForToday(course, currentDay)))
+                .map(course -> CourseSummaryResponse.of(course, getSchedulesByCourse(course)))
                 .collect(Collectors.toList());
     }
 
@@ -324,16 +324,6 @@ public class ProfessorCourseService {
                 .map(Schedule::getStartTime)
                 .min(Comparator.naturalOrder())
                 .orElse(LocalTime.MAX);
-    }
-
-    private List<CourseScheduleResponse> getSchedulesForToday(Course course, String currentDay) {
-        return course.getSchedules().stream()
-                .filter(schedule -> schedule.getDay().equals(currentDay))
-                .map(schedule -> new CourseScheduleResponse(
-                        schedule.getDay(),
-                        schedule.getStartTime().toString(),
-                        schedule.getEndTime().toString()))
-                .collect(Collectors.toList());
     }
 
     private List<Schedule> createSchedules(CourseRequest request, Course course) {


### PR DESCRIPTION
## [BE] 오늘 수업 수정 시 오늘 날짜에 해당하는 Schedule만 표기되는 문제 해결

## #️⃣ 연관된 이슈

#247 

## 📝 작업 내용

오늘 수업 조회 시 Schedule 데이터 처리 방식 수정
- 기존 방식: 오늘 날짜에 해당하는 Schedule 데이터만 응답
- 수정 방식: 모든 Schedule 데이터 응답

## 💬 리뷰 요구사항(선택)

오늘 수업 조회할 때도 전체 Schedule 데이터를 넘기기로 프론트엔드 측과 이야기 나눴습니다. 오늘 수업을 조회할 때 프론트엔드 측에서 오늘 날짜와 일치하는 Schedule 데이터만 화면에 표기가 가능하다고 해서, 백엔드 측에서는 전체 Schedule 데이터를 전달하기로 했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the course schedule display so that all associated schedule details are now shown rather than limiting the view to only the current day’s schedules. This change provides a more complete overview of course schedules for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->