### PR TITLE
학생 SSE connection 부하 개선

### DIFF
--- a/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/service/SseService.java
+++ b/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/service/SseService.java
@@ -22,7 +22,8 @@ public class SseService {
 
     private final Map<String, Sinks.Many<MessageResponse<?>>> sinks = new ConcurrentHashMap<>();
     private final Map<String, Set<String>> courseStudentMap = new ConcurrentHashMap<>();
-    private final int MAX_CONNECTION_TIMEOUT_MINUTES = 10;
+    private final int CONNECTION_TIMEOUT_MINUTES_COURSE = 10;
+    private final int CONNECTION_TIMEOUT_MINUTES_STUDENT = 5;
     private final int RETRY_INTERVAL_SECONDS = 1;
 
     public Flux<ServerSentEvent<MessageResponse<?>>> subscribeCourseMessages(String courseId) {
@@ -81,7 +82,7 @@ public class SseService {
                         sink.asFlux()
                                 .map(data -> ServerSentEvent.<MessageResponse<?>>builder(data).build())
                 )
-                .timeout(Duration.ofMinutes(MAX_CONNECTION_TIMEOUT_MINUTES))
+                .timeout(Duration.ofMinutes(CONNECTION_TIMEOUT_MINUTES_COURSE))
                 .onErrorResume(TimeoutException.class, e -> {
                     log.warn("SSE 연결 제한 시간이 초과되었습니다. : courseId={}", courseId);
                     closeConnection(sink, courseId);
@@ -98,7 +99,7 @@ public class SseService {
                         sink.asFlux()
                                 .map(data -> ServerSentEvent.<MessageResponse<?>>builder(data).build())
                 )
-                .timeout(Duration.ofMinutes(MAX_CONNECTION_TIMEOUT_MINUTES))
+                .timeout(Duration.ofMinutes(CONNECTION_TIMEOUT_MINUTES_STUDENT))
                 .onErrorResume(TimeoutException.class, e -> {
                     log.warn("학생 SSE 연결 제한 시간이 초과되었습니다. : studentId={}", studentId);
                     closeConnection(sink, studentId);


### PR DESCRIPTION
## 학생 SSE connection 부하 개선

## #️⃣ 연관된 이슈

#251 

## 📝 작업 내용

서버에 SSE connection 부하가 발생하는 상황을 개선
- 학생의 경우 connection timeout을 10분->5분으로 수정
  - 연결 유실의 경우 보다 빠르게 connection을 종료시켜 부하를 방지

## 💬 리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted real-time update connections so that course notifications remain active for up to 10 minutes while student notifications now time out after 5 minutes, ensuring improved connection handling and efficient resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->