### PR TITLE
[BE] 수업 생성시 유효성 검사 누락으로 인한 입장 코드 재생성

### DIFF
--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/dto/CourseRequest.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/dto/CourseRequest.java
@@ -13,9 +13,11 @@ import java.util.List;
 @NoArgsConstructor
 public class CourseRequest {
     @NotBlank(message = "수업 이름이 입력되지 않았습니다.")
+    @Size(max = 35, message = "수업 이름은 35자 이내여야 합니다.")
     private String name;
 
     @NotBlank(message = "학수번호가 입력되지 않았습니다.")
+    @Size(max = 10, message = "학수 번호는 10자 이내여야 합니다.")
     private String courseCode;
 
     @Positive(message = "수업 정원이 입력되지 않았습니다.")
@@ -24,6 +26,7 @@ public class CourseRequest {
     private int capacity;
 
     @NotBlank(message = "대학 이름이 입력되지 않았습니다.")
+    @Size(max = 20, message = "대학 이름은 20자 이내여야 합니다.")
     private String university;
 
     @NotNull(message = "수업 종류가 선택되지 않았습니다.")


### PR DESCRIPTION
## #️⃣ 연관된 이슈

 #261 [BE] 수업 생성시 유효성 검사 누락으로 인한 입장 코드 재생성

## 📝 작업 내용
수업 생성 시 요청 값에 대한 유효성 검사가 없어서, 데이터베이스에 데이터를 INSERT할 때 타입 제한을 초과하는 값이 입력되어 DB 관련 오류가 발생했습니다.

특히, 기존 입장 코드 생성 시 `DataIntegrityViolationException`이 발생하면 재생성 로직을 수행하도록 되어 있었는데, 이름이나 학수 번호 등의 길이가 너무 길어 해당 예외가 발생하면서 입장 코드 재생성 로직이 반복적으로 실행되었습니다. 

이를 해결하기 위해, 수업 생성시 유효성 검사를 추가했습니다. 
> 디자인을 해치지 않는 선에서 길이를 정했습니다. 한국의 대학교를 대상으로 했을 때 충분한 길이라고 생각합니다. 
- 강의 이름 : 1자~35자
- 학수 번호 : 1자~10자
- 대학 이름 : 1자~20자


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced stricter input limits for course details. Users now receive immediate feedback if the course name, course code, or university name exceeds the allowed character limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->