### PR TITLE
[FE] 수업 유효성 항목 추가 

### DIFF
--- a/front-end/src/pages/professor/home/components/CourseCard.module.css
+++ b/front-end/src/pages/professor/home/components/CourseCard.module.css
@@ -171,6 +171,8 @@
 .medium .title {
   font: var(--web-title4-bold);
   color: var(--gray-900);
+  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 .medium .meta {
@@ -287,6 +289,8 @@
   display: flex;
   flex-direction: column;
   gap: 42px;
+  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 .large .university {

--- a/front-end/src/pages/professor/home/modal/CourseModal.tsx
+++ b/front-end/src/pages/professor/home/modal/CourseModal.tsx
@@ -240,6 +240,11 @@ const CourseModal = ({ course, onSubmit, onClose }: CourseModalProps) => {
                 ...prev,
                 name: '강의 이름을 입력해 주세요',
               }));
+            } else if (courseForm.name.length > 35) {
+              setFormError((prev) => ({
+                ...prev,
+                name: '강의 이름은 30자 이하로 입력해 주세요',
+              }));
             } else {
               setFormError((prev) => ({ ...prev, name: '' }));
             }
@@ -333,6 +338,11 @@ const CourseModal = ({ course, onSubmit, onClose }: CourseModalProps) => {
                 ...prev,
                 code: '학수번호를 입력해 주세요',
               }));
+            } else if (courseForm.code.length > 10) {
+              setFormError((prev) => ({
+                ...prev,
+                code: '학수번호는 10자 이하로 입력해 주세요',
+              }));
             } else {
               setFormError((prev) => ({ ...prev, code: '' }));
             }
@@ -383,6 +393,11 @@ const CourseModal = ({ course, onSubmit, onClose }: CourseModalProps) => {
               setFormError((prev) => ({
                 ...prev,
                 university: '대학이름을 입력해 주세요',
+              }));
+            } else if (courseForm.university.length > 20) {
+              setFormError((prev) => ({
+                ...prev,
+                university: '대학이름은 20자 이하로 입력해 주세요',
               }));
             } else {
               setFormError((prev) => ({ ...prev, university: '' }));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #263

## 📝 작업 내용

- 강의명, 대학명, 학수번호 유효성 검사 추가
- 강의 명이 숫자일 경우 줄바꿈 적용 안 되는 버그 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced text wrapping on course cards to prevent overflow and improve readability.

- **New Features**
  - Added input validations in the course modal to display helpful error messages when course details exceed the allowed character limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->