### PR TITLE
[BE] SSE connection 부하 문제 개선

### DIFF
--- a/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/service/SseService.java
+++ b/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/service/SseService.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @Service
@@ -23,6 +24,7 @@ public class SseService {
     private final Map<String, Sinks.Many<MessageResponse<?>>> sinks = new ConcurrentHashMap<>();
     private final Map<String, Set<String>> courseStudentMap = new ConcurrentHashMap<>();
     private static final int MAX_SINKS = 1500;
+    private final AtomicInteger currentConnections = new AtomicInteger(0);
     private final int CONNECTION_TIMEOUT_MINUTES_COURSE = 10;
     private final int CONNECTION_TIMEOUT_MINUTES_STUDENT = 5;
     private final int RETRY_INTERVAL_SECONDS = 1;
@@ -32,7 +34,8 @@ public class SseService {
             return Flux.empty();
         }
         Sinks.Many<MessageResponse<?>> sink = sinks.computeIfAbsent(courseId, k -> {
-            if (sinks.size() >= MAX_SINKS) {
+            if (currentConnections.incrementAndGet() > MAX_SINKS) {
+                currentConnections.decrementAndGet();
                 throw new BaseException(SseErrorCode.CONNECTION_LIMIT_EXCEEDED);
             }
             return Sinks.many().multicast().onBackpressureBuffer();
@@ -57,7 +60,8 @@ public class SseService {
             return Flux.empty();
         }
         Sinks.Many<MessageResponse<?>> sink = sinks.computeIfAbsent(studentId, k -> {
-            if (sinks.size() >= MAX_SINKS) {
+            if (currentConnections.incrementAndGet() > MAX_SINKS) {
+                currentConnections.decrementAndGet();
                 throw new BaseException(SseErrorCode.CONNECTION_LIMIT_EXCEEDED);
             }
             return Sinks.many().multicast().onBackpressureBuffer();
@@ -154,19 +158,20 @@ public class SseService {
         if (sink != null) {
             sink.tryEmitComplete();
             sinks.remove(id);
+            currentConnections.decrementAndGet();
         }
     }
 
     private boolean checkIfConnectionFull() {
-        int currentConnections = sinks.size();
-        if (currentConnections >= MAX_SINKS) {
-            log.debug("SSE 연결 제한을 초과했습니다. : 현재 연결 개수 = {}", currentConnections);
+        int connectionCount = currentConnections.get();
+        if (connectionCount >= MAX_SINKS) {
+            log.debug("SSE 연결 제한을 초과했습니다. : 현재 연결 개수 = {}", connectionCount);
             return true;
         }
         return false;
     }
 
     private void showCurrentUsers() {
-        log.debug("현재 {} 명의 사용자가 연결 중입니다. ", sinks.size());
+        log.debug("현재 {} 명의 사용자가 연결 중입니다. ", currentConnections.get());
     }
 }

--- a/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/service/SseService.java
+++ b/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/domain/sse/service/SseService.java
@@ -85,6 +85,7 @@ public class SseService {
     }
 
     private Flux<ServerSentEvent<MessageResponse<?>>> openCourseConnection(Sinks.Many<MessageResponse<?>> sink, ServerSentEvent<MessageResponse<?>> initEvent, String courseId) {
+        showCurrentUsers();
         return Flux.concat(Mono.just(initEvent),
                         sink.asFlux()
                                 .map(data -> ServerSentEvent.<MessageResponse<?>>builder(data).build())
@@ -102,6 +103,7 @@ public class SseService {
     }
 
     private Flux<ServerSentEvent<MessageResponse<?>>> openStudentConnection(Sinks.Many<MessageResponse<?>> sink, ServerSentEvent<MessageResponse<?>> initEvent, String studentId, String courseId) {
+        showCurrentUsers();
         return Flux.concat(Mono.just(initEvent),
                         sink.asFlux()
                                 .map(data -> ServerSentEvent.<MessageResponse<?>>builder(data).build())
@@ -149,5 +151,9 @@ public class SseService {
             return true;
         }
         return false;
+    }
+
+    private void showCurrentUsers() {
+        log.debug("현재 {} 명의 사용자가 연결 중입니다. ", sinks.size());
     }
 }

--- a/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/global/exception/code/SseErrorCode.java
+++ b/back-end/reacton-classroom/src/main/java/com/softeer/reacton_classroom/global/exception/code/SseErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SseErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "전송 대상을 찾을 수 없습니다."),
+    CONNECTION_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "현재 사용자가 너무 많습니다."),
     MESSAGE_SEND_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "서버 문제로 메시지 전송에 실패했습니다.");
 
     private final HttpStatus status;


### PR DESCRIPTION
## [BE] SSE connection 부하 문제 개선

## #️⃣ 연관된 이슈

#251 

## 📝 작업 내용

동시에 너무 많은 SSE 통신 연결 시 OutOfMemoryError가 발생하는 문제 해결
- 최대 연결 가능한 SSE 통신 개수가 1703개임 (#221)
- 임계점을 고려해, 최대 연결 가능한 통신 개수를 1500개로 제한

## 💬 리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a connection limit to enhance system stability by capping active real-time updates.
  - Improved subscription management to prevent new connections once the maximum threshold is reached.
  - Added a new error code for exceeding connection limits, providing clearer feedback to users.
  - Enhanced monitoring with updated logging for active connection counts, ensuring more reliable oversight and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->