### PR TITLE
[BE] 학생과 교수의 access token이 겹치는 문제 해결

### DIFF
--- a/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/StudentCourseController.java
+++ b/back-end/reacton/src/main/java/com/softeer/reacton/domain/course/StudentCourseController.java
@@ -67,7 +67,7 @@ public class StudentCourseController {
         log.debug("입장 코드와 일치하는 수업 참여를 요청합니다. : accessCode = {}", accessCode);
 
         String newAccessToken = studentCourseService.registerCourse(accessCode);
-        ResponseCookie jwtCookie = ResponseCookie.from("access_token", newAccessToken)
+        ResponseCookie jwtCookie = ResponseCookie.from("student_access_token", newAccessToken)
                 .httpOnly(true)
                 .secure(true)
                 .path("/")


### PR DESCRIPTION
## [BE] 학생과 교수의 access token이 겹치는 문제 해결

## #️⃣ 연관된 이슈

#272 

## 📝 작업 내용

학생과 교수 사용자가 같은 브라우저 내에서 동시 접속 시 403 에러 발생하는 문제 해결
- 학생의 쿠키 이름을 다르게 지정함으로써, 쿠키 이름 겹침으로 인해 발생한 문제 해결

## 💬 리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the authentication system to distinctly handle access for professors and students.
  - Updated course registration to use refined access credentials for improved verification.

- **Refactor**
  - Streamlined the token handling process with clear separation for user roles, leading to better clarity in logging and security management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->